### PR TITLE
database-introspection: Use SQL parameters

### DIFF
--- a/libs/database-introspection/src/lib.rs
+++ b/libs/database-introspection/src/lib.rs
@@ -3,6 +3,7 @@ use failure::Fail;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::fmt;
+use prisma_query::ast::ParameterizedValue;
 
 pub mod mysql;
 pub mod postgres;
@@ -22,7 +23,7 @@ pub type IntrospectionResult<T> = core::result::Result<T, IntrospectionError>;
 /// Connection abstraction for the introspection connectors.
 pub trait IntrospectionConnection: Send + Sync + 'static {
     /// Make raw SQL query.
-    fn query_raw(&self, sql: &str, schema: &str) -> prisma_query::Result<prisma_query::connector::ResultSet>;
+    fn query_raw(&self, sql: &str, schema: &str, params: &[ParameterizedValue]) -> prisma_query::Result<prisma_query::connector::ResultSet>;
 }
 
 /// A database introspection connector.

--- a/libs/database-introspection/src/mysql.rs
+++ b/libs/database-introspection/src/mysql.rs
@@ -37,15 +37,13 @@ impl IntrospectionConnector {
 
     fn get_table_names(&self, schema: &str) -> Vec<String> {
         debug!("Getting table names");
-        let sql = format!(
-            "SELECT table_name as table_name FROM information_schema.tables
-            WHERE table_schema = '{}'
+        let sql = "SELECT table_name as table_name FROM information_schema.tables
+            WHERE table_schema = ?
             -- Views are not supported yet
             AND table_type = 'BASE TABLE'
-            ORDER BY table_name",
-            schema
-        );
-        let rows = self.conn.query_raw(&sql, schema).expect("get table names ");
+            ORDER BY table_name";
+        let rows = self.conn.query_raw(sql, schema, &[schema.into()]).expect(
+            "get table names ");
         let names = rows
             .into_iter()
             .map(|row| {
@@ -78,14 +76,13 @@ impl IntrospectionConnector {
     }
 
     fn get_columns(&self, schema: &str, table: &str) -> Vec<Column> {
-        let sql = format!(
-            "SELECT column_name, data_type, column_default, is_nullable, extra
+        let sql = "SELECT column_name, data_type, column_default, is_nullable, extra
             FROM information_schema.columns
-            WHERE table_schema = '{}' AND table_name  = '{}'
-            ORDER BY column_name",
-            schema, table
-        );
-        let rows = self.conn.query_raw(&sql, schema).expect("querying for columns");
+            WHERE table_schema = ? AND table_name = ?
+            ORDER BY column_name";
+        let rows = self.conn.query_raw(sql, schema, &[
+            schema.into(), table.into(),
+        ]).expect("querying for columns");
         let cols = rows
             .into_iter()
             .map(|col| {
@@ -151,20 +148,19 @@ impl IntrospectionConnector {
         // One should think it's unique since it's used to join information_schema.key_column_usage
         // and information_schema.referential_constraints tables in this query lifted from
         // Stack Overflow
-        let sql = format!(
-            "SELECT kcu.constraint_name, kcu.column_name, kcu.referenced_table_name, 
+        let sql = "SELECT kcu.constraint_name, kcu.column_name, kcu.referenced_table_name, 
             kcu.referenced_column_name, kcu.ordinal_position, rc.delete_rule
             FROM information_schema.key_column_usage AS kcu
             INNER JOIN information_schema.referential_constraints AS rc ON
             kcu.constraint_name = rc.constraint_name
-            WHERE kcu.table_schema = '{}' AND kcu.table_name = '{}' AND 
+            WHERE kcu.table_schema = ? AND kcu.table_name = ? AND 
             referenced_column_name IS NOT NULL
-        ",
-            schema, table
-        );
+        ";
         debug!("Introspecting table foreign keys, SQL: '{}'", sql);
 
-        let result_set = self.conn.query_raw(&sql, schema).expect("querying for foreign keys");
+        let result_set = self.conn.query_raw(sql, schema, &[
+            schema.into(), table.into(),
+        ]).expect("querying for foreign keys");
         let mut intermediate_fks: HashMap<String, ForeignKey> = HashMap::new();
         for row in result_set.into_iter() {
             debug!("Got introspection FK row {:#?}", row);
@@ -243,16 +239,15 @@ impl IntrospectionConnector {
     }
 
     fn get_indices(&self, schema: &str, table_name: &str, fk_cols: Vec<String>) -> (Vec<Index>, Option<PrimaryKey>) {
-        let sql = format!(
-            "SELECT DISTINCT
+        let sql = "SELECT DISTINCT
                 index_name, non_unique, column_name, seq_in_index
             FROM INFORMATION_SCHEMA.STATISTICS
-            WHERE table_schema = '{}' AND table_name = '{}'
-        ",
-            schema, table_name
-        );
+            WHERE table_schema = ? AND table_name = ?
+        ";
         debug!("Introspecting indices, SQL: {}", sql);
-        let rows = self.conn.query_raw(&sql, schema).expect("querying for indices");
+        let rows = self.conn.query_raw(sql, schema, &[
+            schema.into(), table_name.into(),
+        ]).expect("querying for indices");
         let mut pk: Option<PrimaryKey> = None;
         let indices = rows
             .into_iter()

--- a/libs/database-introspection/src/postgres.rs
+++ b/libs/database-introspection/src/postgres.rs
@@ -39,15 +39,14 @@ impl IntrospectionConnector {
 
     fn get_table_names(&self, schema: &str) -> Vec<String> {
         debug!("Getting table names");
-        let sql = format!(
-            "SELECT table_name as table_name FROM information_schema.tables
-            WHERE table_schema = '{}'
+        let sql = "SELECT table_name as table_name FROM information_schema.tables
+            WHERE table_schema = $1
             -- Views are not supported yet
             AND table_type = 'BASE TABLE'
-            ORDER BY table_name",
-            schema
-        );
-        let rows = self.conn.query_raw(&sql, schema).expect("get table names ");
+            ORDER BY table_name";
+        let rows = self.conn.query_raw(sql, schema, &[
+            schema.into(),
+        ]).expect("get table names ");
         let names = rows
             .into_iter()
             .map(|row| {
@@ -76,14 +75,13 @@ impl IntrospectionConnector {
     }
 
     fn get_columns(&self, schema: &str, table: &str) -> Vec<Column> {
-        let sql = format!(
-            "SELECT column_name, udt_name, column_default, is_nullable, is_identity, data_type
+        let sql = "SELECT column_name, udt_name, column_default, is_nullable, is_identity, data_type
             FROM information_schema.columns
-            WHERE table_schema = '{}' AND table_name  = '{}'
-            ORDER BY column_name",
-            schema, table
-        );
-        let rows = self.conn.query_raw(&sql, schema).expect("querying for columns");
+            WHERE table_schema = $1 AND table_name = $2
+            ORDER BY column_name";
+        let rows = self.conn.query_raw(&sql, schema, &[
+            schema.into(), table.into(),
+        ]).expect("querying for columns");
         let cols = rows
             .into_iter()
             .map(|col| {
@@ -155,8 +153,7 @@ impl IntrospectionConnector {
     }
 
     fn get_foreign_keys(&self, schema: &str, table: &str) -> Vec<ForeignKey> {
-        let sql = format!(
-            "SELECT 
+        let sql = "SELECT 
                 con.oid as \"con_id\",
                 att2.attname as \"child_column\", 
                 cl.relname as \"parent_table\", 
@@ -176,8 +173,8 @@ impl IntrospectionConnector {
                     join pg_namespace ns on cl.relnamespace = ns.oid
                     join pg_constraint con1 on con1.conrelid = cl.oid
                 WHERE
-                    cl.relname = '{}'
-                    and ns.nspname = '{}'
+                    cl.relname = $1
+                    and ns.nspname = $2
                     and con1.contype = 'f'
             ) con
             JOIN pg_attribute att on
@@ -187,15 +184,15 @@ impl IntrospectionConnector {
             JOIN pg_attribute att2 on
                 att2.attrelid = con.conrelid and att2.attnum = con.parent
             ORDER BY con_id
-            ",
-            table, schema
-        );
+            ";
         debug!("Introspecting table foreign keys, SQL: '{}'", sql);
 
         // One foreign key with multiple columns will be represented here as several
         // rows with the same ID, which we will have to combine into corresponding foreign key
         // objects.
-        let result_set = self.conn.query_raw(&sql, schema).expect("querying for foreign keys");
+        let result_set = self.conn.query_raw(&sql, schema, &[
+            table.into(), schema.into(),
+        ]).expect("querying for foreign keys");
         let mut intermediate_fks: HashMap<i64, ForeignKey> = HashMap::new();
         for row in result_set.into_iter() {
             debug!("Got introspection FK row {:?}", row);
@@ -259,7 +256,7 @@ impl IntrospectionConnector {
 
     fn get_indices(&self, schema: &str, table_name: &str) -> (Vec<Index>, Option<PrimaryKey>) {
         debug!("Getting indices");
-        let sql = format!("SELECT indexInfos.relname as name,
+        let sql = "SELECT indexInfos.relname as name,
             array_agg(columnInfos.attname) as column_names,
             rawIndex.indisunique as is_unique, rawIndex.indisprimary as is_primary_key
             FROM
@@ -283,12 +280,13 @@ impl IntrospectionConnector {
             AND tableInfos.relkind = 'r'
             -- we only consider stuff out of one specific schema
             AND tableInfos.relnamespace = schemaInfo.oid
-            AND schemaInfo.nspname = '{}'
-            AND tableInfos.relname = '{}'
+            AND schemaInfo.nspname = $1
+            AND tableInfos.relname = $2
             GROUP BY tableInfos.relname, indexInfos.relname, rawIndex.indisunique,
-            rawIndex.indisprimary
-        ", schema, table_name);
-        let rows = self.conn.query_raw(&sql, schema).expect("querying for indices");
+            rawIndex.indisprimary";
+        let rows = self.conn.query_raw(&sql, schema, &[
+            schema.into(), table_name.into(),
+        ]).expect("querying for indices");
         let mut pk: Option<PrimaryKey> = None;
         let indices = rows
             .into_iter()
@@ -326,14 +324,11 @@ impl IntrospectionConnector {
 
     fn get_sequences(&self, schema: &str) -> IntrospectionResult<Vec<Sequence>> {
         debug!("Getting sequences");
-        let sql = format!(
-            "SELECT start_value, sequence_name
+        let sql = "SELECT start_value, sequence_name
                   FROM information_schema.sequences
-                  WHERE sequence_schema = '{}'
-                  ",
-            schema
-        );
-        let rows = self.conn.query_raw(&sql, schema).expect("querying for sequences");
+                  WHERE sequence_schema = $1";
+        let rows = self.conn.query_raw(&sql, schema, &[schema.into()]).expect(
+            "querying for sequences");
         let sequences = rows
             .into_iter()
             .map(|seq| {
@@ -362,16 +357,12 @@ impl IntrospectionConnector {
 
     fn get_enums(&self, schema: &str) -> IntrospectionResult<Vec<Enum>> {
         debug!("Getting enums");
-        let sql = format!(
-            "SELECT t.typname as name, e.enumlabel as value
+        let sql = "SELECT t.typname as name, e.enumlabel as value
             FROM pg_type t 
             JOIN pg_enum e ON t.oid = e.enumtypid  
             JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
-            WHERE n.nspname = '{}'
-            ",
-            schema
-        );
-        let rows = self.conn.query_raw(&sql, schema).expect("querying for enums");
+            WHERE n.nspname = $1";
+        let rows = self.conn.query_raw(&sql, schema, &[schema.into()]).expect("querying for enums");
         let mut enum_values: HashMap<String, HashSet<String>> = HashMap::new();
         for row in rows.into_iter() {
             debug!("Got enum row: {:?}", row);

--- a/libs/database-introspection/src/sqlite.rs
+++ b/libs/database-introspection/src/sqlite.rs
@@ -41,9 +41,10 @@ impl IntrospectionConnector {
     }
 
     fn get_table_names(&self, schema: &str) -> Vec<String> {
-        let sql = format!("SELECT name FROM \"{}\".sqlite_master WHERE type='table'", schema);
+        let sql = "SELECT name FROM ?.sqlite_master WHERE type='table'";
         debug!("Introspecting table names with query: '{}'", sql);
-        let result_set = self.conn.query_raw(&sql, schema).expect("get table names");
+        let result_set = self.conn.query_raw(&sql, schema, &[schema.into()]).expect(
+            "get table names");
         let names = result_set
             .into_iter()
             .map(|row| row.get("name").and_then(|x| x.to_string()).unwrap())
@@ -68,9 +69,11 @@ impl IntrospectionConnector {
     }
 
     fn get_columns(&self, schema: &str, table: &str) -> (Vec<Column>, Option<PrimaryKey>) {
-        let sql = format!(r#"Pragma "{}".table_info ("{}")"#, schema, table);
+        let sql = "Pragma ?.table_info (?)";
         debug!("Introspecting table columns, query: '{}'", sql);
-        let result_set = self.conn.query_raw(&sql, schema).unwrap();
+        let result_set = self.conn.query_raw(&sql, schema, &[
+            schema.into(), table.into(),
+        ]).unwrap();
         let mut pk_cols: HashMap<i64, String> = HashMap::new();
         let mut cols: Vec<Column> = result_set
             .into_iter()
@@ -145,9 +148,11 @@ impl IntrospectionConnector {
             pub on_delete_action: ForeignKeyAction,
         }
 
-        let sql = format!(r#"Pragma "{}".foreign_key_list("{}");"#, schema, table);
+        let sql = "Pragma ?.foreign_key_list(?);";
         debug!("Introspecting table foreign keys, SQL: '{}'", sql);
-        let result_set = self.conn.query_raw(&sql, schema).expect("querying for foreign keys");
+        let result_set = self.conn.query_raw(&sql, schema, &[
+            schema.into(), table.into(),
+        ]).expect("querying for foreign keys");
 
         // Since one foreign key with multiple columns will be represented here as several
         // rows with the same ID, we have to use an intermediate representation that gets
@@ -237,11 +242,14 @@ impl IntrospectionConnector {
             is_unique: bool,
         }
 
-        let sql = format!(r#"Pragma "{}".index_list("{}");"#, schema, table);
+        let sql = "Pragma ?.index_list(?);";
         debug!("Introspecting table indices, SQL: '{}'", sql);
-        let result_set = self.conn.query_raw(&sql, schema).expect("querying for indices");
+        let result_set = self.conn.query_raw(&sql, schema, &[
+            schema.into(), table.into(),
+        ]).expect("querying for indices");
         debug!("Got indices introspection results: {:?}", result_set);
-        let re_auto = Regex::new(&format!(r"^sqlite_autoindex_{}_\d+", table)).expect("compile auto index regex");
+        let re_auto = Regex::new(&format!(r"^sqlite_autoindex_{}_\d+", table)).expect(
+            "compile auto index regex");
         let index_reprs: Vec<IndexRepr> = result_set
             .into_iter()
             .filter_map(|row| {
@@ -268,9 +276,11 @@ impl IntrospectionConnector {
                     columns: vec![],
                 };
 
-                let sql = format!(r#"Pragma "{}".index_info("{}");"#, schema, index_repr.name);
+                let sql = "Pragma ?.index_info(?);";
                 debug!("Introspecting table index '{}', SQL: '{}'", index_repr.name, sql);
-                let result_set = self.conn.query_raw(&sql, schema).expect("querying for index info");
+                let result_set = self.conn.query_raw(&sql, schema, &[
+                    schema.into(), index_repr.name.clone().into(),
+                ]).expect("querying for index info");
                 debug!("Got index introspection results: {:?}", result_set);
                 for row in result_set.into_iter() {
                     let pos = row.get("seqno").and_then(|x| x.as_i64()).expect("get seqno") as usize;

--- a/libs/database-introspection/tests/introspection_connection_tests.rs
+++ b/libs/database-introspection/tests/introspection_connection_tests.rs
@@ -2,7 +2,7 @@ use barrel::{types, Migration};
 use database_introspection::*;
 use log::{debug, LevelFilter};
 use pretty_assertions::assert_eq;
-use prisma_query::connector::Queryable;
+use prisma_query::{connector::Queryable, ast::ParameterizedValue};
 use std::collections::HashSet;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -1944,8 +1944,8 @@ struct SqliteConnection {
 }
 
 impl crate::IntrospectionConnection for SqliteConnection {
-    fn query_raw(&self, sql: &str, _schema: &str) -> prisma_query::Result<prisma_query::connector::ResultSet> {
-        self.client.lock().expect("self.client.lock").query_raw(sql, &[])
+    fn query_raw(&self, sql: &str, _schema: &str, params: &[ParameterizedValue]) -> prisma_query::Result<prisma_query::connector::ResultSet> {
+        self.client.lock().expect("self.client.lock").query_raw(sql, params)
     }
 }
 
@@ -1982,8 +1982,8 @@ struct PostgresConnection {
 }
 
 impl crate::IntrospectionConnection for PostgresConnection {
-    fn query_raw(&self, sql: &str, _: &str) -> prisma_query::Result<prisma_query::connector::ResultSet> {
-        self.client.lock().expect("self.client.lock").query_raw(sql, &[])
+    fn query_raw(&self, sql: &str, _: &str, params: &[ParameterizedValue]) -> prisma_query::Result<prisma_query::connector::ResultSet> {
+        self.client.lock().expect("self.client.lock").query_raw(sql, params)
     }
 }
 
@@ -2027,8 +2027,8 @@ struct MySqlConnection {
 }
 
 impl crate::IntrospectionConnection for MySqlConnection {
-    fn query_raw(&self, sql: &str, _: &str) -> prisma_query::Result<prisma_query::connector::ResultSet> {
-        self.client.lock().expect("self.client.lock").query_raw(sql, &[])
+    fn query_raw(&self, sql: &str, _: &str, params: &[ParameterizedValue]) -> prisma_query::Result<prisma_query::connector::ResultSet> {
+        self.client.lock().expect("self.client.lock").query_raw(sql, params)
     }
 }
 

--- a/migration-engine/connectors/sql-migration-connector/src/migration_database.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/migration_database.rs
@@ -18,8 +18,8 @@ pub struct MigrationDatabaseWrapper {
 }
 
 impl database_introspection::IntrospectionConnection for MigrationDatabaseWrapper {
-    fn query_raw(&self, sql: &str, schema: &str) -> prisma_query::Result<prisma_query::connector::ResultSet> {
-        self.database.query_raw(schema, sql, &[])
+    fn query_raw(&self, sql: &str, schema: &str, params: &[ParameterizedValue]) -> prisma_query::Result<prisma_query::connector::ResultSet> {
+        self.database.query_raw(schema, sql, params)
     }
 }
 


### PR DESCRIPTION
Use SQL parameters for queries in database-introspection, to safeguard from SQL injection issues.