### PR TITLE
database-introspection: Use SQL parameters

### DIFF
--- a/libs/database-introspection/src/lib.rs
+++ b/libs/database-introspection/src/lib.rs
@@ -1,5 +1,6 @@
 //! Database introspection.
 use failure::Fail;
+use prisma_query::ast::ParameterizedValue;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::fmt;
@@ -22,7 +23,12 @@ pub type IntrospectionResult<T> = core::result::Result<T, IntrospectionError>;
 /// Connection abstraction for the introspection connectors.
 pub trait IntrospectionConnection: Send + Sync + 'static {
     /// Make raw SQL query.
-    fn query_raw(&self, sql: &str, schema: &str) -> prisma_query::Result<prisma_query::connector::ResultSet>;
+    fn query_raw(
+        &self,
+        sql: &str,
+        schema: &str,
+        params: &[ParameterizedValue],
+    ) -> prisma_query::Result<prisma_query::connector::ResultSet>;
 }
 
 /// A database introspection connector.

--- a/libs/database-introspection/tests/introspection_connection_tests.rs
+++ b/libs/database-introspection/tests/introspection_connection_tests.rs
@@ -2,7 +2,7 @@ use barrel::{types, Migration};
 use database_introspection::*;
 use log::{debug, LevelFilter};
 use pretty_assertions::assert_eq;
-use prisma_query::connector::Queryable;
+use prisma_query::{ast::ParameterizedValue, connector::Queryable};
 use std::collections::HashSet;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -1937,8 +1937,13 @@ struct SqliteConnection {
 }
 
 impl crate::IntrospectionConnection for SqliteConnection {
-    fn query_raw(&self, sql: &str, _schema: &str) -> prisma_query::Result<prisma_query::connector::ResultSet> {
-        self.client.lock().expect("self.client.lock").query_raw(sql, &[])
+    fn query_raw(
+        &self,
+        sql: &str,
+        _schema: &str,
+        params: &[ParameterizedValue],
+    ) -> prisma_query::Result<prisma_query::connector::ResultSet> {
+        self.client.lock().expect("self.client.lock").query_raw(sql, params)
     }
 }
 
@@ -1975,8 +1980,13 @@ struct PostgresConnection {
 }
 
 impl crate::IntrospectionConnection for PostgresConnection {
-    fn query_raw(&self, sql: &str, _: &str) -> prisma_query::Result<prisma_query::connector::ResultSet> {
-        self.client.lock().expect("self.client.lock").query_raw(sql, &[])
+    fn query_raw(
+        &self,
+        sql: &str,
+        _: &str,
+        params: &[ParameterizedValue],
+    ) -> prisma_query::Result<prisma_query::connector::ResultSet> {
+        self.client.lock().expect("self.client.lock").query_raw(sql, params)
     }
 }
 
@@ -2020,8 +2030,13 @@ struct MySqlConnection {
 }
 
 impl crate::IntrospectionConnection for MySqlConnection {
-    fn query_raw(&self, sql: &str, _: &str) -> prisma_query::Result<prisma_query::connector::ResultSet> {
-        self.client.lock().expect("self.client.lock").query_raw(sql, &[])
+    fn query_raw(
+        &self,
+        sql: &str,
+        _: &str,
+        params: &[ParameterizedValue],
+    ) -> prisma_query::Result<prisma_query::connector::ResultSet> {
+        self.client.lock().expect("self.client.lock").query_raw(sql, params)
     }
 }
 

--- a/migration-engine/connectors/sql-migration-connector/src/migration_database.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/migration_database.rs
@@ -18,8 +18,8 @@ pub struct MigrationDatabaseWrapper {
 }
 
 impl database_introspection::IntrospectionConnection for MigrationDatabaseWrapper {
-    fn query_raw(&self, sql: &str, schema: &str) -> prisma_query::Result<prisma_query::connector::ResultSet> {
-        self.database.query_raw(schema, sql, &[])
+    fn query_raw(&self, sql: &str, schema: &str, params: &[ParameterizedValue]) -> prisma_query::Result<prisma_query::connector::ResultSet> {
+        self.database.query_raw(schema, sql, params)
     }
 }
 


### PR DESCRIPTION
In database-introspection, use SQL parameters, to safeguard against injection through string interpolation.