### PR TITLE
database-introspection: Fix autoincrement detection for SQLite

### DIFF
--- a/libs/database-introspection/src/sqlite.rs
+++ b/libs/database-introspection/src/sqlite.rs
@@ -97,7 +97,7 @@ impl IntrospectionConnector {
                     tpe,
                     arity: arity.clone(),
                     default: default_value.clone(),
-                    auto_increment: pk_col > 0,
+                    auto_increment: false,
                 };
                 if pk_col > 0 {
                     pk_cols.insert(pk_col, col.name.clone());
@@ -129,6 +129,20 @@ impl IntrospectionConnector {
                 for i in col_idxs {
                     columns.push(pk_cols[i].clone());
                 }
+
+                // If the primary key is a single integer column, it's autoincrementing
+                if pk_cols.len() == 1 {
+                    let pk_col = &columns[0];
+                    for col in cols.iter_mut() {
+                        if &col.name == pk_col && &col.tpe.raw.to_lowercase() == "integer" {
+                            debug!(
+                                "Detected that the primary key column corresponds to rowid and \
+                                is auto incrementing");
+                            col.auto_increment = true;
+                        }
+                    }
+                }
+
                 debug!("Determined that table has primary key with columns {:?}", columns);
                 Some(PrimaryKey { columns })
             }

--- a/libs/database-introspection/tests/introspection_connection_tests.rs
+++ b/libs/database-introspection/tests/introspection_connection_tests.rs
@@ -1153,7 +1153,7 @@ fn sqlite_column_types_must_work() {
         t.add_column("int4_col", types::integer());
         t.add_column("text_col", types::text());
         t.add_column("real_col", types::float());
-        t.add_column("primary_col", types::primary());
+        t.add_column("primary_col", types::custom("INTEGER PRIMARY KEY"));
     });
 
     let full_sql = migration.make::<barrel::backend::Pg>();
@@ -1194,7 +1194,7 @@ fn sqlite_column_types_must_work() {
         Column {
             name: "primary_col".to_string(),
             tpe: ColumnType {
-                raw: "SERIAL".to_string(),
+                raw: "INTEGER".to_string(),
                 family: ColumnTypeFamily::Int,
             },
             arity: ColumnArity::Required,
@@ -1661,6 +1661,60 @@ fn mysql_foreign_key_on_delete_must_be_handled() {
                     on_delete_action: ForeignKeyAction::SetNull,
                 },
             ],
+        }
+    );
+}
+
+#[test]
+fn sqlite_composite_primary_key_must_work() {
+    setup();
+
+    let sql = format!(
+        "CREATE TABLE \"{0}\".User (
+            id INTEGER NOT NULL,
+            name VARCHAR(255) NOT NULL,
+            PRIMARY KEY(id, name)
+        )",
+        SCHEMA
+    );
+    let inspector = get_sqlite_connector(&sql);
+
+    let schema = inspector.introspect(SCHEMA).expect("introspection");
+    let table = schema.get_table("User").expect("couldn't get User table");
+    let mut expected_columns = vec![
+        Column {
+            name: "id".to_string(),
+            tpe: ColumnType {
+                raw: "INTEGER".to_string(),
+                family: ColumnTypeFamily::Int,
+            },
+            arity: ColumnArity::Required,
+            default: None,
+            auto_increment: false,
+        },
+        Column {
+            name: "name".to_string(),
+            tpe: ColumnType {
+                raw: "VARCHAR(255)".to_string(),
+                family: ColumnTypeFamily::String,
+            },
+            arity: ColumnArity::Required,
+            default: None,
+            auto_increment: false,
+        },
+    ];
+    expected_columns.sort_unstable_by_key(|c| c.name.to_owned());
+
+    assert_eq!(
+        table,
+        &Table {
+            name: "User".to_string(),
+            columns: expected_columns,
+            indices: vec![],
+            primary_key: Some(PrimaryKey {
+                columns: vec!["id".to_string(), "name".to_string()],
+            }),
+            foreign_keys: vec![],
         }
     );
 }

--- a/libs/database-introspection/tests/introspection_connection_tests.rs
+++ b/libs/database-introspection/tests/introspection_connection_tests.rs
@@ -1153,10 +1153,10 @@ fn sqlite_column_types_must_work() {
         t.add_column("int4_col", types::integer());
         t.add_column("text_col", types::text());
         t.add_column("real_col", types::float());
-        t.add_column("primary_col", types::custom("INTEGER PRIMARY KEY"));
+        t.add_column("primary_col", types::primary());
     });
 
-    let full_sql = migration.make::<barrel::backend::Pg>();
+    let full_sql = migration.make::<barrel::backend::Sqlite>();
     let inspector = get_sqlite_connector(&full_sql);
     let result = inspector.introspect(SCHEMA).expect("introspection");
     let table = result.get_table("User").expect("couldn't get User table");
@@ -1184,7 +1184,7 @@ fn sqlite_column_types_must_work() {
         Column {
             name: "real_col".to_string(),
             tpe: ColumnType {
-                raw: "FLOAT".to_string(),
+                raw: "REAL".to_string(),
                 family: ColumnTypeFamily::Float,
             },
             arity: ColumnArity::Required,


### PR DESCRIPTION
Fix autoincrement detection for SQLite primary keys, which don't use the `AUTOINCREMENT` keyword.