### PR TITLE
Warn when a migration would drop a table containing data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,11 +227,6 @@ dependencies = [
 
 [[package]]
 name = "barrel"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "barrel"
 version = "0.6.3-alpha.0"
 source = "git+https://github.com/aknuds1/barrel.git#ad9a0b30fe867d74037b900f7c28f8ae7f5e5e3f"
 
@@ -1336,7 +1331,7 @@ dependencies = [
 name = "migration-core"
 version = "0.1.0"
 dependencies = [
- "barrel 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "barrel 0.6.3-alpha.0 (git+https://github.com/aknuds1/barrel.git)",
  "boolinator 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2765,7 +2760,7 @@ dependencies = [
 name = "sql-migration-connector"
 version = "0.1.0"
 dependencies = [
- "barrel 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "barrel 0.6.3-alpha.0 (git+https://github.com/aknuds1/barrel.git)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "datamodel 0.1.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3657,7 +3652,6 @@ dependencies = [
 "checksum autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "22130e92352b948e7e82a49cdb0aa94f2211761117f29e052dd397c1ac33542b"
 "checksum backtrace 0.3.34 (registry+https://github.com/rust-lang/crates.io-index)" = "b5164d292487f037ece34ec0de2fcede2faa162f085dd96d2385ab81b12765ba"
 "checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
-"checksum barrel 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5497422862a693058ae19670b3e99e999ef048cd3f26f9ffceca2ed103ccc0ad"
 "checksum barrel 0.6.3-alpha.0 (git+https://github.com/aknuds1/barrel.git)" = "<none>"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 "checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"

--- a/migration-engine/connectors/migration-connector/src/destructive_changes_checker.rs
+++ b/migration-engine/connectors/migration-connector/src/destructive_changes_checker.rs
@@ -1,25 +1,49 @@
+use crate::ConnectorResult;
 use std::marker::PhantomData;
 
 pub trait DestructiveChangesChecker<T>: Send + Sync + 'static
 where
-    T: Send + Sync + 'static,
+    T: 'static,
 {
-    fn check(&self, database_migration: &T) -> Vec<MigrationErrorOrWarning>;
+    fn check(&self, database_migration: &T) -> ConnectorResult<DestructiveChangeDiagnostics>;
+}
+
+#[derive(Debug)]
+pub struct DestructiveChangeDiagnostics {
+    pub errors: Vec<MigrationError>,
+    pub warnings: Vec<MigrationWarning>,
+}
+
+impl DestructiveChangeDiagnostics {
+    pub fn new() -> DestructiveChangeDiagnostics {
+        DestructiveChangeDiagnostics {
+            errors: Vec::new(),
+            warnings: Vec::new(),
+        }
+    }
+
+    pub fn add_warning<T: Into<Option<MigrationWarning>>>(&mut self, warning: T) {
+        if let Some(warning) = warning.into() {
+            self.warnings.push(warning)
+        }
+    }
+
+    pub fn has_warnings(&self) -> bool {
+        !self.warnings.is_empty()
+    }
 }
 
 pub enum MigrationErrorOrWarning {
-    Error(MigrationWarning),
-    Warning(MigrationError),
+    Error(MigrationError),
+    Warning(MigrationWarning),
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, PartialEq)]
 pub struct MigrationWarning {
-    pub tpe: String,
     pub description: String,
-    pub field: Option<String>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, PartialEq)]
 pub struct MigrationError {
     pub tpe: String,
     pub description: String,
@@ -42,7 +66,7 @@ impl<T> DestructiveChangesChecker<T> for EmptyDestructiveChangesChecker<T>
 where
     T: Send + Sync + 'static,
 {
-    fn check(&self, _database_migration: &T) -> Vec<MigrationErrorOrWarning> {
-        Vec::new()
+    fn check(&self, _database_migration: &T) -> ConnectorResult<DestructiveChangeDiagnostics> {
+        Ok(DestructiveChangeDiagnostics::new())
     }
 }

--- a/migration-engine/connectors/sql-migration-connector/Cargo.toml
+++ b/migration-engine/connectors/sql-migration-connector/Cargo.toml
@@ -13,7 +13,7 @@ chrono = { version = "0.4" }
 serde_json = "1.0"
 serde = "1.0"
 prisma-query = { git = "https://github.com/prisma/prisma-query.git" }
-barrel = { version = "0.6.2", features = ["sqlite3", "mysql", "pg"] }
+barrel = { version = "0.6.3-alpha.0", features = ["sqlite3", "mysql", "pg"] }
 itertools = "0.8"
 url = "1.7.2"
 postgres = { version = "0.16.0-rc.1", features = ["with-serde_json-1", "with-chrono-0_4", "with-uuid-0_7"] }

--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -184,7 +184,10 @@ impl SqlMigrationConnector {
             conn: Arc::clone(&conn),
         });
 
-        let destructive_changes_checker = Arc::new(SqlDestructiveChangesChecker {});
+        let destructive_changes_checker = Arc::new(SqlDestructiveChangesChecker {
+            schema_name: schema_name.clone(),
+            database: Arc::clone(&conn),
+        });
 
         Self {
             url: url.to_string(),

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker.rs
@@ -1,11 +1,60 @@
-use crate::SqlMigration;
+use crate::{DropTable, DropTables, MigrationDatabase, SqlError, SqlMigration, SqlMigrationStep, SqlResult};
 use migration_connector::*;
+use prisma_query::ast::*;
+use std::sync::Arc;
 
-pub struct SqlDestructiveChangesChecker {}
+pub struct SqlDestructiveChangesChecker {
+    pub schema_name: String,
+    pub database: Arc<dyn MigrationDatabase + Send + Sync>,
+}
+
+impl SqlDestructiveChangesChecker {
+    fn check_table_drop(&self, table_name: &str) -> SqlResult<Option<MigrationWarning>> {
+        let query = Select::from_table((self.schema_name.as_str(), table_name)).value(count(asterisk()));
+        let result_set = self.database.query(&self.schema_name, query.into())?;
+        let first_row = result_set.first().ok_or_else(|| {
+            SqlError::Generic("No row was returned when checking for existing rows in dropped table.".to_owned())
+        })?;
+        let rows_count: i64 = first_row.at(0).and_then(|value| value.as_i64()).ok_or_else(|| {
+            SqlError::Generic("No count was returned when checking for existing rows in dropped table.".to_owned())
+        })?;
+
+        if rows_count > 0 {
+            Ok(Some(MigrationWarning {
+                description: format!(
+                    "You are about to drop the table `{table_name}`, which is not empty ({rows_count} rows).",
+                    table_name = table_name,
+                    rows_count = rows_count
+                ),
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+}
 
 #[allow(unused, dead_code)]
 impl DestructiveChangesChecker<SqlMigration> for SqlDestructiveChangesChecker {
-    fn check(&self, database_migration: &SqlMigration) -> Vec<MigrationErrorOrWarning> {
-        vec![]
+    fn check(&self, database_migration: &SqlMigration) -> ConnectorResult<DestructiveChangeDiagnostics> {
+        let mut diagnostics = DestructiveChangeDiagnostics::new();
+
+        for step in &database_migration.steps {
+            // Here, check for each table we are going to delete if it is empty. If not, return a
+            // warning.
+            match step {
+                SqlMigrationStep::DropTable(DropTable { name }) => {
+                    diagnostics.add_warning(self.check_table_drop(name)?);
+                }
+                SqlMigrationStep::DropTables(DropTables { names }) => {
+                    for name in names {
+                        diagnostics.add_warning(self.check_table_drop(name)?);
+                    }
+                }
+                // do nothing
+                _ => (),
+            }
+        }
+
+        Ok(diagnostics)
     }
 }

--- a/migration-engine/core/Cargo.toml
+++ b/migration-engine/core/Cargo.toml
@@ -33,7 +33,7 @@ tokio-threadpool = "0.1"
 
 [dev-dependencies]
 prisma-query = { git = "https://github.com/prisma/prisma-query.git" }
-barrel = { version = "0.6.2", features = ["sqlite3", "mysql", "pg"] }
+barrel = { version = "0.6.3-alpha.0", features = ["sqlite3", "mysql", "pg"] }
 pretty_assertions = "0.6"
 sql-schema-describer = { path = "../../libs/sql-schema-describer" }
 

--- a/migration-engine/core/tests/apply_migration_tests.rs
+++ b/migration-engine/core/tests/apply_migration_tests.rs
@@ -15,14 +15,14 @@ fn single_watch_migrations_must_work() {
             create_id_field_step("Test", "id", ScalarType::Int),
         ];
 
-        let db_schema_1 = apply_migration(api, steps.clone(), "watch-0001");
+        let db_schema_1 = apply_migration(api, steps.clone(), "watch-0001").sql_schema;
         let migrations = migration_persistence.load_all();
 
         assert_eq!(migrations.len(), 1);
         assert_eq!(migrations.first().unwrap().name, "watch-0001");
 
         let custom_migration_id = "a-custom-migration-id";
-        let db_schema_2 = apply_migration(api, steps.clone(), custom_migration_id);
+        let db_schema_2 = apply_migration(api, steps.clone(), custom_migration_id).sql_schema;
 
         assert_eq!(db_schema_1, db_schema_2);
 
@@ -53,7 +53,7 @@ fn multiple_watch_migrations_must_work() {
         assert_eq!(migrations[0].name, "watch-0001");
 
         let steps2 = vec![create_field_step("Test", "field", ScalarType::String)];
-        let db_schema_2 = apply_migration(api, steps2.clone(), "watch-0002");
+        let db_schema_2 = apply_migration(api, steps2.clone(), "watch-0002").sql_schema;
         let migrations = migration_persistence.load_all();
 
         assert_eq!(migrations.len(), 2);
@@ -66,7 +66,7 @@ fn multiple_watch_migrations_must_work() {
         final_steps.append(&mut steps1.clone());
         final_steps.append(&mut steps2.clone());
 
-        let final_db_schema = apply_migration(api, final_steps, custom_migration_id);
+        let final_db_schema = apply_migration(api, final_steps, custom_migration_id).sql_schema;
 
         assert_eq!(db_schema_2, final_db_schema);
 
@@ -92,7 +92,7 @@ fn steps_equivalence_criteria_is_satisfied_when_leaving_watch_mode() {
             create_id_field_step("Test", "id", ScalarType::Int),
         ];
 
-        let db_schema1 = apply_migration(api, steps1.clone(), "watch-0001");
+        let db_schema1 = apply_migration(api, steps1.clone(), "watch-0001").sql_schema;
 
         let steps2 = vec![create_field_step("Test", "field", ScalarType::String)];
         let _ = apply_migration(api, steps2.clone(), "watch-0002");
@@ -104,7 +104,7 @@ fn steps_equivalence_criteria_is_satisfied_when_leaving_watch_mode() {
         let mut final_steps = Vec::new();
         final_steps.append(&mut steps1.clone()); // steps2 and steps3 eliminate each other
 
-        let final_db_schema = apply_migration(api, final_steps, custom_migration_id);
+        let final_db_schema = apply_migration(api, final_steps, custom_migration_id).sql_schema;
         assert_eq!(db_schema1, final_db_schema);
         let migrations = migration_persistence.load_all();
         assert_eq!(migrations[0].name, "watch-0001");
@@ -137,7 +137,7 @@ fn must_handle_additional_steps_when_transitioning_out_of_watch_mode() {
         final_steps.append(&mut steps2.clone());
         final_steps.append(&mut additional_steps.clone());
 
-        let final_db_schema = apply_migration(api, final_steps, custom_migration_id);
+        let final_db_schema = apply_migration(api, final_steps, custom_migration_id).sql_schema;
         assert_eq!(final_db_schema.tables.len(), 1);
         let table = final_db_schema.table_bang("Test");
         assert_eq!(table.columns.len(), 3);

--- a/migration-engine/core/tests/existing_data_tests.rs
+++ b/migration-engine/core/tests/existing_data_tests.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case)]
 #![allow(unused)]
 mod test_harness;
+use migration_connector::MigrationWarning;
 use pretty_assertions::{assert_eq, assert_ne};
 use prisma_query::ast::*;
 use sql_migration_connector::SqlFamily;
@@ -19,7 +20,7 @@ fn adding_a_required_field_if_there_is_data() {
                 A
             }
         "#;
-        infer_and_apply(api, &dm);
+        infer_and_apply(api, &dm).sql_schema;
 
         let conn = database(sql_family);
         let insert = Insert::single_into((SCHEMA_NAME, "Test")).value("id", "test");
@@ -101,4 +102,39 @@ fn adding_a_required_field_must_use_the_default_value_for_migrations() {
             assert_eq!(row["string"].as_str().unwrap(), "test_string");
         }
     });
+}
+
+#[test]
+fn dropping_a_table_with_rows_should_warn() {
+    test_each_connector(|sql_family, engine| {
+        let dm = r#"
+                    model Test {
+                        id String @id @default(cuid())
+                    }
+                "#;
+        let original_database_schema = infer_and_apply(engine, &dm).sql_schema;
+
+        let conn = database(sql_family);
+        let insert = Insert::single_into((SCHEMA_NAME, "Test")).value("id", "test");
+
+        conn.execute(SCHEMA_NAME, insert.into()).unwrap();
+
+        let dm = "";
+
+        let InferAndApplyOutput {
+            migration_output,
+            sql_schema: final_database_schema,
+        } = infer_and_apply(engine, &dm);
+
+        // The schema should not change because the migration should not run if there are warnings
+        // and the force flag isn't passed.
+        assert_eq!(original_database_schema, final_database_schema);
+
+        assert_eq!(
+            migration_output.warnings,
+            &[MigrationWarning {
+                description: "You are about to drop the table `Test`, which is not empty (1 rows).".into()
+            }]
+        );
+    })
 }

--- a/migration-engine/core/tests/existing_databases_tests.rs
+++ b/migration-engine/core/tests/existing_databases_tests.rs
@@ -23,7 +23,7 @@ fn adding_a_model_for_an_existing_table_must_work() {
                 id Int @id
             }
         "#;
-        let result = infer_and_apply(api, &dm);
+        let result = infer_and_apply(api, &dm).sql_schema;
         assert_eq!(initial_result, result);
     });
 }
@@ -45,7 +45,7 @@ fn removing_a_model_for_a_table_that_is_already_deleted_must_work() {
                 id Int @id
             }
         "#;
-        let initial_result = infer_and_apply(api, &dm1);
+        let initial_result = infer_and_apply(api, &dm1).sql_schema;
         assert!(initial_result.has_table("Post"));
 
         let result = barrel.execute(|migration| {
@@ -58,7 +58,7 @@ fn removing_a_model_for_a_table_that_is_already_deleted_must_work() {
                 id Int @id
             }
         "#;
-        let final_result = infer_and_apply(api, &dm2);
+        let final_result = infer_and_apply(api, &dm2).sql_schema;
         assert_eq!(result, final_result);
     });
 }
@@ -78,7 +78,7 @@ fn creating_a_field_for_an_existing_column_with_a_compatible_type_must_work() {
                 title String
             }
         "#;
-        let result = infer_and_apply(api, &dm);
+        let result = infer_and_apply(api, &dm).sql_schema;
         assert_eq!(initial_result, result);
     });
 }
@@ -102,7 +102,7 @@ fn creating_a_field_for_an_existing_column_and_changing_its_type_must_work() {
                 title String @unique
             }
         "#;
-        let result = infer_and_apply(api, &dm);
+        let result = infer_and_apply(api, &dm).sql_schema;
         let table = result.table_bang("Blog");
         let column = table.column_bang("title");
         assert_eq!(column.tpe.family, ColumnTypeFamily::String);
@@ -131,7 +131,7 @@ fn creating_a_field_for_an_existing_column_and_simultaneously_making_it_optional
                 title String?
             }
         "#;
-        let result = infer_and_apply(api, &dm);
+        let result = infer_and_apply(api, &dm).sql_schema;
         let column = result.table_bang("Blog").column_bang("title");
         assert_eq!(column.is_required(), false);
     });
@@ -145,7 +145,7 @@ fn creating_a_scalar_list_field_for_an_existing_table_must_work() {
                 id Int @id
             }
         "#;
-        let initial_result = infer_and_apply(api, &dm1);
+        let initial_result = infer_and_apply(api, &dm1).sql_schema;
         assert!(!initial_result.has_table("Blog_tags"));
 
         let mut result = barrel.execute(|migration| {
@@ -180,7 +180,7 @@ fn creating_a_scalar_list_field_for_an_existing_table_must_work() {
                 tags String[]
             }
         "#;
-        let mut final_result = infer_and_apply(api, &dm2);
+        let mut final_result = infer_and_apply(api, &dm2).sql_schema;
         for table in &mut final_result.tables {
             if table.name == "Blog_tags" {
                 // can't set that properly up again
@@ -201,7 +201,7 @@ fn delete_a_field_for_a_non_existent_column_must_work() {
                 title String
             }
         "#;
-        let initial_result = infer_and_apply(api, &dm1);
+        let initial_result = infer_and_apply(api, &dm1).sql_schema;
         assert_eq!(initial_result.table_bang("Blog").column("title").is_some(), true);
 
         let result = barrel.execute(|migration| {
@@ -218,7 +218,7 @@ fn delete_a_field_for_a_non_existent_column_must_work() {
                 id Int @id
             }
         "#;
-        let final_result = infer_and_apply(api, &dm2);
+        let final_result = infer_and_apply(api, &dm2).sql_schema;
         assert_eq!(result, final_result);
     });
 }
@@ -232,7 +232,7 @@ fn deleting_a_scalar_list_field_for_a_non_existent_list_table_must_work() {
                 tags String[]
             }
         "#;
-        let initial_result = infer_and_apply(api, &dm1);
+        let initial_result = infer_and_apply(api, &dm1).sql_schema;
         assert!(initial_result.has_table("Blog_tags"));
 
         let result = barrel.execute(|migration| {
@@ -245,7 +245,7 @@ fn deleting_a_scalar_list_field_for_a_non_existent_list_table_must_work() {
                 id Int @id
             }
         "#;
-        let final_result = infer_and_apply(api, &dm2);
+        let final_result = infer_and_apply(api, &dm2).sql_schema;
         assert_eq!(result, final_result);
     });
 }
@@ -259,7 +259,7 @@ fn updating_a_field_for_a_non_existent_column() {
                 title String
             }
         "#;
-        let initial_result = infer_and_apply(api, &dm1);
+        let initial_result = infer_and_apply(api, &dm1).sql_schema;
         let initial_column = initial_result.table_bang("Blog").column_bang("title");
         assert_eq!(initial_column.tpe.family, ColumnTypeFamily::String);
 
@@ -278,7 +278,7 @@ fn updating_a_field_for_a_non_existent_column() {
                 title Int @unique
             }
         "#;
-        let final_result = infer_and_apply(api, &dm2);
+        let final_result = infer_and_apply(api, &dm2).sql_schema;
         let final_column = final_result.table_bang("Blog").column_bang("title");
         assert_eq!(final_column.tpe.family, ColumnTypeFamily::Int);
         let index = final_result
@@ -300,7 +300,7 @@ fn renaming_a_field_where_the_column_was_already_renamed_must_work() {
                 title String
             }
         "#;
-        let initial_result = infer_and_apply(api, &dm1);
+        let initial_result = infer_and_apply(api, &dm1).sql_schema;
         let initial_column = initial_result.table_bang("Blog").column_bang("title");
         assert_eq!(initial_column.tpe.family, ColumnTypeFamily::String);
 
@@ -321,7 +321,7 @@ fn renaming_a_field_where_the_column_was_already_renamed_must_work() {
             }
         "#;
 
-        let final_result = infer_and_apply(api, &dm2);
+        let final_result = infer_and_apply(api, &dm2).sql_schema;
         let final_column = final_result.table_bang("Blog").column_bang("new_title");
 
         assert_eq!(final_column.tpe.family, ColumnTypeFamily::Float);

--- a/migration-engine/core/tests/migration_tests.rs
+++ b/migration-engine/core/tests/migration_tests.rs
@@ -25,7 +25,7 @@ fn adding_a_scalar_field_must_work() {
                 B
             }
         "#;
-        let result = infer_and_apply(api, &dm2);
+        let result = infer_and_apply(api, &dm2).sql_schema;
         let table = result.table_bang("Test");
         table.columns.iter().for_each(|c| assert_eq!(c.is_required(), true));
 
@@ -71,7 +71,7 @@ fn adding_an_optional_field_must_work() {
                 field String?
             }
         "#;
-        let result = infer_and_apply(api, &dm2);
+        let result = infer_and_apply(api, &dm2).sql_schema;
         let column = result.table_bang("Test").column_bang("field");
         assert_eq!(column.is_required(), false);
     });
@@ -85,7 +85,7 @@ fn adding_an_id_field_with_a_special_name_must_work() {
                 specialName String @id @default(cuid())
             }
         "#;
-        let result = infer_and_apply(api, &dm2);
+        let result = infer_and_apply(api, &dm2).sql_schema;
         let column = result.table_bang("Test").column("specialName");
         assert_eq!(column.is_some(), true);
     });
@@ -99,7 +99,7 @@ fn adding_an_id_field_of_type_int_must_work() {
                 myId Int @id
             }
         "#;
-        let result = infer_and_apply(api, &dm2);
+        let result = infer_and_apply(api, &dm2).sql_schema;
         let column = result.table_bang("Test").column_bang("myId");
         match sql_family {
             SqlFamily::Postgres => {
@@ -122,7 +122,7 @@ fn removing_a_scalar_field_must_work() {
                 field String
             }
         "#;
-        let result = infer_and_apply(api, &dm1);
+        let result = infer_and_apply(api, &dm1).sql_schema;
         let column1 = result.table_bang("Test").column("field");
         assert_eq!(column1.is_some(), true);
 
@@ -131,7 +131,7 @@ fn removing_a_scalar_field_must_work() {
                 id String @id @default(cuid())
             }
         "#;
-        let result = infer_and_apply(api, &dm2);
+        let result = infer_and_apply(api, &dm2).sql_schema;
         let column2 = result.table_bang("Test").column("field");
         assert_eq!(column2.is_some(), false);
     });
@@ -146,7 +146,7 @@ fn can_handle_reserved_sql_keywords_for_model_name() {
                 field String
             }
         "#;
-        let result = infer_and_apply(api, &dm1);
+        let result = infer_and_apply(api, &dm1).sql_schema;
         let column = result.table_bang("Group").column_bang("field");
         assert_eq!(column.tpe.family, ColumnTypeFamily::String);
 
@@ -156,7 +156,7 @@ fn can_handle_reserved_sql_keywords_for_model_name() {
                 field Int
             }
         "#;
-        let result = infer_and_apply(api, &dm2);
+        let result = infer_and_apply(api, &dm2).sql_schema;
         let column = result.table_bang("Group").column_bang("field");
         assert_eq!(column.tpe.family, ColumnTypeFamily::Int);
     });
@@ -171,7 +171,7 @@ fn can_handle_reserved_sql_keywords_for_field_name() {
                 Group String
             }
         "#;
-        let result = infer_and_apply(api, &dm1);
+        let result = infer_and_apply(api, &dm1).sql_schema;
         let column = result.table_bang("Test").column_bang("Group");
         assert_eq!(column.tpe.family, ColumnTypeFamily::String);
 
@@ -181,7 +181,7 @@ fn can_handle_reserved_sql_keywords_for_field_name() {
                 Group Int
             }
         "#;
-        let result = infer_and_apply(api, &dm2);
+        let result = infer_and_apply(api, &dm2).sql_schema;
         let column = result.table_bang("Test").column_bang("Group");
         assert_eq!(column.tpe.family, ColumnTypeFamily::Int);
     });
@@ -196,7 +196,7 @@ fn update_type_of_scalar_field_must_work() {
                 field String
             }
         "#;
-        let result = infer_and_apply(api, &dm1);
+        let result = infer_and_apply(api, &dm1).sql_schema;
         let column1 = result.table_bang("Test").column_bang("field");
         assert_eq!(column1.tpe.family, ColumnTypeFamily::String);
 
@@ -206,7 +206,7 @@ fn update_type_of_scalar_field_must_work() {
                 field Int
             }
         "#;
-        let result = infer_and_apply(api, &dm2);
+        let result = infer_and_apply(api, &dm2).sql_schema;
         let column2 = result.table_bang("Test").column_bang("field");
         assert_eq!(column2.tpe.family, ColumnTypeFamily::Int);
     });
@@ -224,7 +224,7 @@ fn changing_the_type_of_an_id_field_must_work() {
                 id Int @id
             }
         "#;
-        let result = infer_and_apply(api, &dm1);
+        let result = infer_and_apply(api, &dm1).sql_schema;
         let table = result.table_bang("A");
         let column = table.column_bang("b");
         assert_eq!(column.tpe.family, ColumnTypeFamily::Int);
@@ -247,7 +247,7 @@ fn changing_the_type_of_an_id_field_must_work() {
                 id String @id @default(cuid())
             }
         "#;
-        let result = infer_and_apply(api, &dm2);
+        let result = infer_and_apply(api, &dm2).sql_schema;
         let table = result.table_bang("A");
         let column = table.column_bang("b");
         assert_eq!(column.tpe.family, ColumnTypeFamily::String);
@@ -272,7 +272,7 @@ fn updating_db_name_of_a_scalar_field_must_work() {
                 field String @map(name:"name1")
             }
         "#;
-        let result = infer_and_apply(api, &dm1);
+        let result = infer_and_apply(api, &dm1).sql_schema;
         assert_eq!(result.table_bang("A").column("name1").is_some(), true);
 
         let dm2 = r#"
@@ -281,7 +281,7 @@ fn updating_db_name_of_a_scalar_field_must_work() {
                 field String @map(name:"name2")
             }
         "#;
-        let result = infer_and_apply(api, &dm2);
+        let result = infer_and_apply(api, &dm2).sql_schema;
         assert_eq!(result.table_bang("A").column("name1").is_some(), false);
         assert_eq!(result.table_bang("A").column("name2").is_some(), true);
     });
@@ -301,7 +301,7 @@ fn changing_a_relation_field_to_a_scalar_field_must_work() {
                 a A // remove this once the implicit back relation field is implemented
             }
         "#;
-        let result = infer_and_apply(api, &dm1);
+        let result = infer_and_apply(api, &dm1).sql_schema;
         let table = result.table_bang("A");
         let column = table.column_bang("b");
         assert_eq!(column.tpe.family, ColumnTypeFamily::Int);
@@ -324,7 +324,7 @@ fn changing_a_relation_field_to_a_scalar_field_must_work() {
                 id Int @id
             }
         "#;
-        let result = infer_and_apply(api, &dm2);
+        let result = infer_and_apply(api, &dm2).sql_schema;
         let table = result.table_bang("A");
         let column = table.column_bang("b");
         assert_eq!(column.tpe.family, ColumnTypeFamily::String);
@@ -344,7 +344,7 @@ fn changing_a_scalar_field_to_a_relation_field_must_work() {
                 id Int @id
             }
         "#;
-        let result = infer_and_apply(api, &dm1);
+        let result = infer_and_apply(api, &dm1).sql_schema;
         let table = result.table_bang("A");
         let column = table.column_bang("b");
         assert_eq!(column.tpe.family, ColumnTypeFamily::String);
@@ -360,7 +360,7 @@ fn changing_a_scalar_field_to_a_relation_field_must_work() {
                 a A // remove this once the implicit back relation field is implemented
             }
         "#;
-        let result = infer_and_apply(api, &dm2);
+        let result = infer_and_apply(api, &dm2).sql_schema;
         let table = result.table_bang("A");
         let column = result.table_bang("A").column_bang("b");
         assert_eq!(column.tpe.family, ColumnTypeFamily::Int);
@@ -390,7 +390,7 @@ fn adding_a_many_to_many_relation_must_result_in_a_prisma_style_relation_table()
                 as A[]
             }
         "#;
-        let result = infer_and_apply(api, &dm1);
+        let result = infer_and_apply(api, &dm1).sql_schema;
         let relation_table = result.table_bang("_AToB");
         println!("{:?}", relation_table.foreign_keys);
         assert_eq!(relation_table.columns.len(), 2);
@@ -434,7 +434,7 @@ fn adding_a_many_to_many_relation_with_custom_name_must_work() {
             }
         "#;
 
-        let result = infer_and_apply(api, &dm1);
+        let result = infer_and_apply(api, &dm1).sql_schema;
         let relation_table = result.table_bang("_my_relation");
         assert_eq!(relation_table.columns.len(), 2);
 
@@ -504,7 +504,7 @@ fn adding_an_inline_relation_must_result_in_a_foreign_key_in_the_model_table() {
                 id Int @id
             }
         "#;
-        let result = dbg!(infer_and_apply(api, &dm1));
+        let result = dbg!(infer_and_apply(api, &dm1).sql_schema);
         let table = result.table_bang("A");
         let column = table.column_bang("b");
         assert_eq!(column.tpe.family, ColumnTypeFamily::Int);
@@ -533,7 +533,7 @@ fn specifying_a_db_name_for_an_inline_relation_must_work() {
                 id Int @id
             }
         "#;
-        let result = infer_and_apply(api, &dm1);
+        let result = infer_and_apply(api, &dm1).sql_schema;
         let table = result.table_bang("A");
         let column = table.column_bang("b_column");
         assert_eq!(column.tpe.family, ColumnTypeFamily::Int);
@@ -562,7 +562,7 @@ fn adding_an_inline_relation_to_a_model_with_an_exotic_id_type() {
                 id String @id @default(cuid())
             }
         "#;
-        let result = dbg!(infer_and_apply(api, &dm1));
+        let result = dbg!(infer_and_apply(api, &dm1).sql_schema);
         let table = result.table_bang("A");
         let column = table.column_bang("b");
         assert_eq!(column.tpe.family, ColumnTypeFamily::String);
@@ -591,7 +591,7 @@ fn removing_an_inline_relation_must_work() {
                 id Int @id
             }
         "#;
-        let result = dbg!(infer_and_apply(api, &dm1));
+        let result = infer_and_apply(api, &dm1).sql_schema;
         let column = result.table_bang("A").column("b");
         assert_eq!(column.is_some(), true);
 
@@ -604,7 +604,7 @@ fn removing_an_inline_relation_must_work() {
                 id Int @id
             }
         "#;
-        let result = dbg!(infer_and_apply(api, &dm2));
+        let result = infer_and_apply(api, &dm2).sql_schema;
         let column = result.table_bang("A").column("b");
         assert_eq!(column.is_some(), false);
     });
@@ -623,7 +623,7 @@ fn moving_an_inline_relation_to_the_other_side_must_work() {
                 id Int @id
             }
         "#;
-        let result = infer_and_apply(api, &dm1);
+        let result = infer_and_apply(api, &dm1).sql_schema;
         let table = result.table_bang("A");
         assert_eq!(
             table.foreign_keys,
@@ -645,7 +645,7 @@ fn moving_an_inline_relation_to_the_other_side_must_work() {
                 a A @relation(references: [id])
             }
         "#;
-        let result = infer_and_apply(api, &dm2);
+        let result = infer_and_apply(api, &dm2).sql_schema;
         let table = result.table_bang("B");
         assert_eq!(
             table.foreign_keys,
@@ -668,7 +668,7 @@ fn adding_a_new_unique_field_must_work() {
                 field String @unique
             }
         "#;
-        let result = infer_and_apply(api, &dm1);
+        let result = infer_and_apply(api, &dm1).sql_schema;
         let index = result
             .table_bang("A")
             .indices
@@ -688,7 +688,7 @@ fn unique_in_conjunction_with_custom_column_name_must_work() {
                 field String @unique @map("custom_field_name")
             }
         "#;
-        let result = infer_and_apply(api, &dm1);
+        let result = infer_and_apply(api, &dm1).sql_schema;
         let index = result
             .table_bang("A")
             .indices
@@ -710,7 +710,7 @@ fn sqlite_must_recreate_indexes() {
                 field String @unique
             }
         "#;
-        let result = infer_and_apply(api, &dm1);
+        let result = infer_and_apply(api, &dm1).sql_schema;
         let index = result
             .table_bang("A")
             .indices
@@ -726,7 +726,7 @@ fn sqlite_must_recreate_indexes() {
                 other String
             }
         "#;
-        let result = infer_and_apply(api, &dm2);
+        let result = infer_and_apply(api, &dm2).sql_schema;
         let index = result
             .table_bang("A")
             .indices
@@ -747,7 +747,7 @@ fn removing_an_existing_unique_field_must_work() {
                 field String @unique
             }
         "#;
-        let result = infer_and_apply(api, &dm1);
+        let result = infer_and_apply(api, &dm1).sql_schema;
         let index = result
             .table_bang("A")
             .indices
@@ -761,7 +761,7 @@ fn removing_an_existing_unique_field_must_work() {
                 id    Int    @id
             }
         "#;
-        let result = dbg!(infer_and_apply(api, &dm2));
+        let result = infer_and_apply(api, &dm2).sql_schema;
         let index = result
             .table_bang("A")
             .indices
@@ -780,7 +780,7 @@ fn adding_unique_to_an_existing_field_must_work() {
                 field String
             }
         "#;
-        let result = infer_and_apply(api, &dm1);
+        let result = infer_and_apply(api, &dm1).sql_schema;
         let index = result
             .table_bang("A")
             .indices
@@ -794,7 +794,7 @@ fn adding_unique_to_an_existing_field_must_work() {
                 field String @unique
             }
         "#;
-        let result = infer_and_apply(api, &dm2);
+        let result = infer_and_apply(api, &dm2).sql_schema;
         let index = result
             .table_bang("A")
             .indices
@@ -815,7 +815,7 @@ fn removing_unique_from_an_existing_field_must_work() {
                 field String @unique
             }
         "#;
-        let result = infer_and_apply(api, &dm1);
+        let result = infer_and_apply(api, &dm1).sql_schema;
         let index = result
             .table_bang("A")
             .indices
@@ -830,7 +830,7 @@ fn removing_unique_from_an_existing_field_must_work() {
                 field String
             }
         "#;
-        let result = dbg!(infer_and_apply(api, &dm2));
+        let result = infer_and_apply(api, &dm2).sql_schema;
         let index = result
             .table_bang("A")
             .indices
@@ -855,7 +855,7 @@ fn adding_a_scalar_list_for_a_modelwith_id_type_int_must_work() {
               ERROR
             }
         "#;
-        let result = infer_and_apply(api, &dm1);
+        let result = infer_and_apply(api, &dm1).sql_schema;
         let scalar_list_table_for_strings = result.table_bang("A_strings");
         let node_id_column = scalar_list_table_for_strings.column_bang("nodeId");
         assert_eq!(node_id_column.tpe.family, ColumnTypeFamily::Int);
@@ -882,7 +882,7 @@ fn updating_a_model_with_a_scalar_list_to_a_different_id_type_must_work() {
                 strings String[]
             }
         "#;
-        let result = infer_and_apply(api, &dm);
+        let result = infer_and_apply(api, &dm).sql_schema;
         let node_id_column = result.table_bang("A_strings").column_bang("nodeId");
         assert_eq!(node_id_column.tpe.family, ColumnTypeFamily::Int);
 
@@ -892,7 +892,7 @@ fn updating_a_model_with_a_scalar_list_to_a_different_id_type_must_work() {
                 strings String[]
             }
         "#;
-        let result = infer_and_apply(api, &dm);
+        let result = infer_and_apply(api, &dm).sql_schema;
         let node_id_column = result.table_bang("A_strings").column_bang("nodeId");
         assert_eq!(node_id_column.tpe.family, ColumnTypeFamily::String);
     });
@@ -909,7 +909,7 @@ fn reserved_sql_key_words_must_work() {
                 childGroups Group[] @relation(name: "ChildGroups")
             }
         "#;
-        let result = infer_and_apply(api, &dm);
+        let result = infer_and_apply(api, &dm).sql_schema;
 
         let table = result.table_bang("Group");
         let relation_column = table.column_bang("parent");

--- a/migration-engine/core/tests/test_harness/command_helpers.rs
+++ b/migration-engine/core/tests/test_harness/command_helpers.rs
@@ -3,11 +3,21 @@ use migration_connector::*;
 use migration_core::{api::GenericApi, commands::*};
 use sql_schema_describer::*;
 
-pub fn infer_and_apply(api: &dyn GenericApi, datamodel: &str) -> SqlSchema {
+#[derive(Debug)]
+pub struct InferAndApplyOutput {
+    pub sql_schema: SqlSchema,
+    pub migration_output: MigrationStepsResultOutput,
+}
+
+pub fn infer_and_apply(api: &dyn GenericApi, datamodel: &str) -> InferAndApplyOutput {
     infer_and_apply_with_migration_id(api, &datamodel, "the-migration-id")
 }
 
-pub fn infer_and_apply_with_migration_id(api: &dyn GenericApi, datamodel: &str, migration_id: &str) -> SqlSchema {
+pub fn infer_and_apply_with_migration_id(
+    api: &dyn GenericApi,
+    datamodel: &str,
+    migration_id: &str,
+) -> InferAndApplyOutput {
     let input = InferMigrationStepsInput {
         migration_id: migration_id.to_string(),
         datamodel: datamodel.to_string(),
@@ -30,21 +40,27 @@ pub fn run_infer_command(api: &dyn GenericApi, input: InferMigrationStepsInput) 
     output.datamodel_steps
 }
 
-pub fn apply_migration(api: &dyn GenericApi, steps: Vec<MigrationStep>, migration_id: &str) -> SqlSchema {
+pub fn apply_migration(api: &dyn GenericApi, steps: Vec<MigrationStep>, migration_id: &str) -> InferAndApplyOutput {
     let input = ApplyMigrationInput {
         migration_id: migration_id.to_string(),
         steps: steps,
         force: None,
     };
 
-    let output = api.apply_migration(&input).expect("ApplyMigration failed");
+    let migration_output = api.apply_migration(&input).expect("ApplyMigration failed");
 
     assert!(
-        output.general_errors.is_empty(),
-        format!("ApplyMigration returned unexpected errors: {:?}", output.general_errors)
+        migration_output.general_errors.is_empty(),
+        format!(
+            "ApplyMigration returned unexpected errors: {:?}",
+            migration_output.general_errors
+        )
     );
 
-    introspect_database(api)
+    InferAndApplyOutput {
+        sql_schema: introspect_database(api),
+        migration_output,
+    }
 }
 
 pub fn unapply_migration(api: &dyn GenericApi) -> SqlSchema {

--- a/migration-engine/core/tests/unapply_migration_tests.rs
+++ b/migration-engine/core/tests/unapply_migration_tests.rs
@@ -14,7 +14,7 @@ fn unapply_must_work() {
             }
         "#;
 
-        let result1 = infer_and_apply(api, &dm1);
+        let result1 = infer_and_apply(api, &dm1).sql_schema;
         assert_eq!(result1.table_bang("Test").column("field").is_some(), true);
 
         let dm2 = r#"
@@ -23,14 +23,14 @@ fn unapply_must_work() {
             }
         "#;
 
-        let result2 = infer_and_apply(api, &dm2);
+        let result2 = infer_and_apply(api, &dm2).sql_schema;
         assert_eq!(result2.table_bang("Test").column("field").is_some(), false);
 
         let result3 = unapply_migration(api);
         assert_eq!(result1, result3);
 
         // reapply the migration again
-        let result4 = infer_and_apply(api, &dm2);
+        let result4 = infer_and_apply(api, &dm2).sql_schema;
         assert_eq!(result2, result4);
     });
 }


### PR DESCRIPTION
Additional changes:

- Make the `infer_and_apply` test helper return the migration output in
addition to the new database schema.
- Prevent migrations from altering the database if there are warnings
and the `force` flag wasn't passed.