### PR TITLE
Warn when a migration would drop a table containing data

### DIFF
--- a/migration-engine/connectors/migration-connector/src/destructive_changes_checker.rs
+++ b/migration-engine/connectors/migration-connector/src/destructive_changes_checker.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 
 pub trait DestructiveChangesChecker<T>: Send + Sync + 'static
 where
-    T: 'static,
+    T: Send + Sync + 'static,
 {
     fn check(&self, database_migration: &T) -> ConnectorResult<DestructiveChangeDiagnostics>;
 }

--- a/migration-engine/connectors/migration-connector/src/destructive_changes_checker.rs
+++ b/migration-engine/connectors/migration-connector/src/destructive_changes_checker.rs
@@ -1,25 +1,49 @@
+use crate::ConnectorResult;
 use std::marker::PhantomData;
 
 pub trait DestructiveChangesChecker<T>: Send + Sync + 'static
 where
-    T: Send + Sync + 'static,
+    T: 'static,
 {
-    fn check(&self, database_migration: &T) -> Vec<MigrationErrorOrWarning>;
+    fn check(&self, database_migration: &T) -> ConnectorResult<DestructiveChangeDiagnostics>;
+}
+
+#[derive(Debug)]
+pub struct DestructiveChangeDiagnostics {
+    pub errors: Vec<MigrationError>,
+    pub warnings: Vec<MigrationWarning>,
+}
+
+impl DestructiveChangeDiagnostics {
+    pub fn new() -> DestructiveChangeDiagnostics {
+        DestructiveChangeDiagnostics {
+            errors: Vec::new(),
+            warnings: Vec::new(),
+        }
+    }
+
+    pub fn add_warning<T: Into<Option<MigrationWarning>>>(&mut self, warning: T) {
+        if let Some(warning) = warning.into() {
+            self.warnings.push(warning)
+        }
+    }
+
+    pub fn has_warnings(&self) -> bool {
+        !self.warnings.is_empty()
+    }
 }
 
 pub enum MigrationErrorOrWarning {
-    Error(MigrationWarning),
-    Warning(MigrationError),
+    Error(MigrationError),
+    Warning(MigrationWarning),
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, PartialEq)]
 pub struct MigrationWarning {
-    pub tpe: String,
     pub description: String,
-    pub field: Option<String>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, PartialEq)]
 pub struct MigrationError {
     pub tpe: String,
     pub description: String,
@@ -42,7 +66,7 @@ impl<T> DestructiveChangesChecker<T> for EmptyDestructiveChangesChecker<T>
 where
     T: Send + Sync + 'static,
 {
-    fn check(&self, _database_migration: &T) -> Vec<MigrationErrorOrWarning> {
-        Vec::new()
+    fn check(&self, _database_migration: &T) -> ConnectorResult<DestructiveChangeDiagnostics> {
+        Ok(DestructiveChangeDiagnostics::new())
     }
 }

--- a/migration-engine/connectors/migration-connector/src/destructive_changes_checker.rs
+++ b/migration-engine/connectors/migration-connector/src/destructive_changes_checker.rs
@@ -8,6 +8,7 @@ where
     fn check(&self, database_migration: &T) -> ConnectorResult<DestructiveChangeDiagnostics>;
 }
 
+/// The errors and warnings emitted by the [DestructiveChangesChecker](trait.DestructiveChangesChecker.html).
 #[derive(Debug)]
 pub struct DestructiveChangeDiagnostics {
     pub errors: Vec<MigrationError>,

--- a/migration-engine/connectors/migration-connector/src/destructive_changes_checker.rs
+++ b/migration-engine/connectors/migration-connector/src/destructive_changes_checker.rs
@@ -33,11 +33,6 @@ impl DestructiveChangeDiagnostics {
     }
 }
 
-pub enum MigrationErrorOrWarning {
-    Error(MigrationError),
-    Warning(MigrationWarning),
-}
-
 #[derive(Debug, Serialize, PartialEq)]
 pub struct MigrationWarning {
     pub description: String,

--- a/migration-engine/connectors/sql-migration-connector/src/error.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/error.rs
@@ -8,9 +8,6 @@ pub enum SqlError {
     #[fail(display = "{}", _0)]
     Generic(String),
 
-    #[fail(display = "{}", column_name)]
-    UnknownColumnDropped { column_name: String },
-
     #[fail(display = "Error connecting to the database {}", _0)]
     ConnectionError(&'static str),
 

--- a/migration-engine/connectors/sql-migration-connector/src/error.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/error.rs
@@ -8,6 +8,9 @@ pub enum SqlError {
     #[fail(display = "{}", _0)]
     Generic(String),
 
+    #[fail(display = "{}", column_name)]
+    UnknownColumnDropped { column_name: String },
+
     #[fail(display = "Error connecting to the database {}", _0)]
     ConnectionError(&'static str),
 

--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -153,7 +153,10 @@ impl SqlMigrationConnector {
             conn: Arc::clone(&conn),
         });
 
-        let destructive_changes_checker = Arc::new(SqlDestructiveChangesChecker {});
+        let destructive_changes_checker = Arc::new(SqlDestructiveChangesChecker {
+            schema_name: schema_name.clone(),
+            database: Arc::clone(&conn),
+        });
 
         Self {
             url: url.to_string(),

--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -183,21 +183,15 @@ impl MigrationConnector for SqlMigrationConnector {
     fn create_database(&self, db_name: &str) -> ConnectorResult<()> {
         match self.sql_family {
             SqlFamily::Postgres => {
-                self.database.query_raw(
-                    "",
-                    &format!("CREATE DATABASE \"{}\"", db_name),
-                    &[]
-                )?;
+                self.database
+                    .query_raw("", &format!("CREATE DATABASE \"{}\"", db_name), &[])?;
 
                 Ok(())
             }
             SqlFamily::Sqlite => Ok(()),
             SqlFamily::Mysql => {
-                self.database.query_raw(
-                    "",
-                    &format!("CREATE DATABASE `{}`", db_name),
-                    &[]
-                )?;
+                self.database
+                    .query_raw("", &format!("CREATE DATABASE `{}`", db_name), &[])?;
 
                 Ok(())
             }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_migration_inferrer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_migration_inferrer.rs
@@ -260,6 +260,7 @@ fn fix(_alter_table: &AlterTable, current: &Table, next: &Table, schema_name: &s
             SqlMigrationStep::RawSql { raw: sql.to_string() }
         },
     );
+
     result.push(SqlMigrationStep::DropTable(DropTable {
         name: current.name.clone(),
     }));

--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -13,7 +13,7 @@ pub struct SqlDatabaseStepApplier {
 #[allow(unused, dead_code)]
 impl DatabaseMigrationStepApplier<SqlMigration> for SqlDatabaseStepApplier {
     fn apply_step(&self, database_migration: &SqlMigration, index: usize) -> ConnectorResult<bool> {
-        Ok(self.apply_next_step(&database_migration.steps, index)?)
+        Ok(self.apply_next_step(&database_migration.corrected_steps, index)?)
     }
 
     fn unapply_step(&self, database_migration: &SqlMigration, index: usize) -> ConnectorResult<bool> {
@@ -56,7 +56,7 @@ fn render_steps_pretty(
     schema_name: &str,
 ) -> ConnectorResult<serde_json::Value> {
     let jsons = database_migration
-        .steps
+        .corrected_steps
         .iter()
         .map(|step| {
             let cloned = step.clone();

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker.rs
@@ -1,11 +1,60 @@
-use crate::SqlMigration;
+use crate::{DropTable, DropTables, MigrationDatabase, SqlError, SqlMigration, SqlMigrationStep, SqlResult};
 use migration_connector::*;
+use prisma_query::ast::*;
+use std::sync::Arc;
 
-pub struct SqlDestructiveChangesChecker {}
+pub struct SqlDestructiveChangesChecker {
+    pub schema_name: String,
+    pub database: Arc<dyn MigrationDatabase + Send + Sync>,
+}
+
+impl SqlDestructiveChangesChecker {
+    fn check_table_drop(&self, table_name: &str) -> SqlResult<Option<MigrationWarning>> {
+        let query = Select::from_table((self.schema_name.as_str(), table_name)).value(count(asterisk()));
+        let result_set = self.database.query(&self.schema_name, query.into())?;
+        let first_row = result_set.first().ok_or_else(|| {
+            SqlError::Generic("No row was returned when checking for existing rows in dropped table.".to_owned())
+        })?;
+        let rows_count: i64 = first_row.at(0).and_then(|value| value.as_i64()).ok_or_else(|| {
+            SqlError::Generic("No count was returned when checking for existing rows in dropped table.".to_owned())
+        })?;
+
+        if rows_count > 0 {
+            Ok(Some(MigrationWarning {
+                description: format!(
+                    "You are about to drop the table `{table_name}`, which is not empty ({rows_count} rows).",
+                    table_name = table_name,
+                    rows_count = rows_count
+                ),
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+}
 
 #[allow(unused, dead_code)]
 impl DestructiveChangesChecker<SqlMigration> for SqlDestructiveChangesChecker {
-    fn check(&self, database_migration: &SqlMigration) -> Vec<MigrationErrorOrWarning> {
-        vec![]
+    fn check(&self, database_migration: &SqlMigration) -> ConnectorResult<DestructiveChangeDiagnostics> {
+        let mut diagnostics = DestructiveChangeDiagnostics::new();
+
+        for step in &database_migration.steps {
+            // Here, check for each table we are going to delete if it is empty. If not, return a
+            // warning.
+            match step {
+                SqlMigrationStep::DropTable(DropTable { name }) => {
+                    diagnostics.add_warning(self.check_table_drop(name)?);
+                }
+                SqlMigrationStep::DropTables(DropTables { names }) => {
+                    for name in names {
+                        diagnostics.add_warning(self.check_table_drop(name)?);
+                    }
+                }
+                // do nothing
+                _ => (),
+            }
+        }
+
+        Ok(diagnostics)
     }
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker.rs
@@ -83,7 +83,7 @@ impl DestructiveChangesChecker<SqlMigration> for SqlDestructiveChangesChecker {
     fn check(&self, database_migration: &SqlMigration) -> ConnectorResult<DestructiveChangeDiagnostics> {
         let mut diagnostics = DestructiveChangeDiagnostics::new();
 
-        for step in &database_migration.steps {
+        for step in &database_migration.original_steps {
             match step {
                 SqlMigrationStep::AlterTable(alter_table) => {
                     alter_table

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker.rs
@@ -1,6 +1,10 @@
-use crate::{DropTable, DropTables, MigrationDatabase, SqlError, SqlMigration, SqlMigrationStep, SqlResult};
+use crate::{
+    DropColumn, DropTable, DropTables, MigrationDatabase, SqlError, SqlMigration, SqlMigrationStep, SqlResult,
+    TableChange,
+};
 use migration_connector::*;
 use prisma_query::ast::*;
+use sql_schema_describer::ColumnArity;
 use std::sync::Arc;
 
 pub struct SqlDestructiveChangesChecker {
@@ -9,7 +13,7 @@ pub struct SqlDestructiveChangesChecker {
 }
 
 impl SqlDestructiveChangesChecker {
-    fn check_table_drop(&self, table_name: &str) -> SqlResult<Option<MigrationWarning>> {
+    fn check_table_drop(&self, table_name: &str, diagnostics: &mut DestructiveChangeDiagnostics) -> SqlResult<()> {
         let query = Select::from_table((self.schema_name.as_str(), table_name)).value(count(asterisk()));
         let result_set = self.database.query(&self.schema_name, query.into())?;
         let first_row = result_set.first().ok_or_else(|| {
@@ -20,34 +24,127 @@ impl SqlDestructiveChangesChecker {
         })?;
 
         if rows_count > 0 {
-            Ok(Some(MigrationWarning {
+            diagnostics.add_warning(MigrationWarning {
                 description: format!(
                     "You are about to drop the table `{table_name}`, which is not empty ({rows_count} rows).",
                     table_name = table_name,
                     rows_count = rows_count
                 ),
-            }))
-        } else {
-            Ok(None)
+            });
         }
+
+        Ok(())
+    }
+
+    /// Emit a warning when we drop a column that contains non-null, non-default values.
+    fn check_column_drop(
+        &self,
+        DropColumn { name: column_name }: &DropColumn,
+        table: &sql_schema_describer::Table,
+        diagnostics: &mut DestructiveChangeDiagnostics,
+    ) -> SqlResult<()> {
+        let column_info = table
+            .columns
+            .iter()
+            .find(|column| column.name == *column_name)
+            .ok_or_else(|| SqlError::UnknownColumnDropped {
+                column_name: column_name.to_owned(),
+            })?;
+
+        // We want to check if the column is "used" before dropping it. This means checking for
+        // values that are not the default value or NULL.
+        //
+        // PROBLEM: are NULL and default (non-null) value semantically different for a column that
+        // is nullable with a default?
+
+        let mut condition = prisma_query::ast::ConditionTree::default();
+
+        // When the column is nullable, we need to check for non-null values.
+        if let ColumnArity::Nullable = column_info.arity {
+            condition = condition.and(column_name.as_str().is_not_null());
+        };
+
+        // When the column has a default value, we need to check for values different from the
+        // default.
+        if let Some(default_value) = &column_info.default {
+            // FIXME: condition = condition.and(column_name.as_str().not_equals(cast(default_value.as_str(), column_info.tpe.raw)))
+            condition = condition.and(column_name.as_str().not_equals(default_value.as_str()));
+        };
+
+        let query = Select::from_table((self.schema_name.as_str(), table.name.as_str()))
+            .value(count(prisma_query::ast::Column::new(column_name.as_str())))
+            .so_that(condition);
+
+        let values_count: i64 = self
+            .database
+            .query(&self.schema_name, query.into())
+            .map_err(SqlError::from)
+            .and_then(|result_set| {
+                result_set
+                    .first()
+                    .as_ref()
+                    .and_then(|row| row.at(0))
+                    .and_then(|count| count.as_i64())
+                    .ok_or_else(|| {
+                        SqlError::Generic("Unexpected result set shape when checking dropped columns.".to_owned())
+                    })
+            })?;
+
+        if values_count > 0 {
+            diagnostics.add_warning(MigrationWarning {
+                description: format!(
+                    "You are about to drop the column `{column_name}` on the `{table_name}` table, which still contains {values_count} non-null, non-default values.",
+                    column_name=column_name,
+                    table_name=&table.name,
+                    values_count=values_count,
+                )
+            })
+        }
+
+        Ok(())
     }
 }
 
-#[allow(unused, dead_code)]
 impl DestructiveChangesChecker<SqlMigration> for SqlDestructiveChangesChecker {
     fn check(&self, database_migration: &SqlMigration) -> ConnectorResult<DestructiveChangeDiagnostics> {
         let mut diagnostics = DestructiveChangeDiagnostics::new();
 
         for step in &database_migration.steps {
-            // Here, check for each table we are going to delete if it is empty. If not, return a
-            // warning.
             match step {
+                SqlMigrationStep::AlterTable(alter_table) => {
+                    alter_table
+                        .changes
+                        .iter()
+                        .map(|change| match *change {
+                            TableChange::DropColumn(ref drop_column) => {
+                                // The table in alter_table is the updated table, but we want to
+                                // check against the current state of the table.
+                                //
+                                // TODO: discuss whether Generic is the right error variant (should
+                                // we have an InvariantViolation variant or similar?)
+                                let before_table = database_migration
+                                    .before
+                                    .get_table(&alter_table.table.name)
+                                    .ok_or_else(|| {
+                                        SqlError::Generic(format!(
+                                            "Internal Error: dropping column {} on previously-unknown table {}",
+                                            drop_column.name, &alter_table.table.name
+                                        ))
+                                    })?;
+                                self.check_column_drop(drop_column, before_table, &mut diagnostics)
+                            }
+                            _ => Ok(()),
+                        })
+                        .collect::<Result<(), SqlError>>()?;
+                }
+                // Here, check for each table we are going to delete if it is empty. If
+                // not, return a warning.
                 SqlMigrationStep::DropTable(DropTable { name }) => {
-                    diagnostics.add_warning(self.check_table_drop(name)?);
+                    self.check_table_drop(name, &mut diagnostics)?;
                 }
                 SqlMigrationStep::DropTables(DropTables { names }) => {
                     for name in names {
-                        diagnostics.add_warning(self.check_table_drop(name)?);
+                        self.check_table_drop(name, &mut diagnostics)?;
                     }
                 }
                 // do nothing

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
@@ -6,7 +6,11 @@ use sql_schema_describer::*;
 pub struct SqlMigration {
     pub before: SqlSchema,
     pub after: SqlSchema,
-    pub steps: Vec<SqlMigrationStep>,
+    pub original_steps: Vec<SqlMigrationStep>,
+    /// The `original_steps`, but with specific corrections applied (notably for SQLite) when the
+    /// original steps cannot be applied directly, e.g. because some operations are not supported
+    /// by the database.
+    pub corrected_steps: Vec<SqlMigrationStep>,
     pub rollback: Vec<SqlMigrationStep>,
 }
 
@@ -15,7 +19,8 @@ impl SqlMigration {
         SqlMigration {
             before: SqlSchema::empty(),
             after: SqlSchema::empty(),
-            steps: Vec::new(),
+            original_steps: Vec::new(),
+            corrected_steps: Vec::new(),
             rollback: Vec::new(),
         }
     }

--- a/migration-engine/core/src/api.rs
+++ b/migration-engine/core/src/api.rs
@@ -17,7 +17,7 @@ where
 impl<C, D> MigrationApi<C, D>
 where
     C: MigrationConnector<DatabaseMigration = D>,
-    D: DatabaseMigrationMarker + 'static,
+    D: DatabaseMigrationMarker + Send + Sync + 'static,
 {
     pub fn new(connector: C) -> crate::Result<Self> {
         let engine = MigrationEngine::new(connector)?;

--- a/migration-engine/core/src/commands/apply_migration.rs
+++ b/migration-engine/core/src/commands/apply_migration.rs
@@ -103,7 +103,10 @@ impl<'a> ApplyMigrationCommand<'a> {
 
         let diagnostics = connector.destructive_changes_checker().check(&database_migration)?;
 
-        match (diagnostics.has_warnings(), self.input.force.unwrap_or(false)) {
+        // We always force the migrations for now to preserve backwards-compatibility (i.e. never
+        // cancelling migrations). Once the lift CLI is ready, the `force` option will default to
+        // `false`.
+        match (diagnostics.has_warnings(), self.input.force.unwrap_or(true)) {
             // We have no warnings, or the force flag is passed.
             (false, _) | (true, true) => {
                 let saved_migration = migration_persistence.create(migration);

--- a/migration-engine/core/src/commands/apply_migration.rs
+++ b/migration-engine/core/src/commands/apply_migration.rs
@@ -19,7 +19,7 @@ impl<'a> MigrationCommand<'a> for ApplyMigrationCommand<'a> {
     fn execute<C, D>(&self, engine: &MigrationEngine<C, D>) -> CommandResult<Self::Output>
     where
         C: MigrationConnector<DatabaseMigration = D>,
-        D: DatabaseMigrationMarker + 'static,
+        D: DatabaseMigrationMarker + Send + Sync + 'static,
     {
         debug!("{:?}", self.input);
 
@@ -42,7 +42,7 @@ impl<'a> ApplyMigrationCommand<'a> {
     ) -> CommandResult<MigrationStepsResultOutput>
     where
         C: MigrationConnector<DatabaseMigration = D>,
-        D: DatabaseMigrationMarker + 'static,
+        D: DatabaseMigrationMarker + Send + Sync + 'static,
     {
         let connector = engine.connector();
         let migration_persistence = connector.migration_persistence();
@@ -59,7 +59,7 @@ impl<'a> ApplyMigrationCommand<'a> {
     fn handle_normal_migration<C, D>(&self, engine: &MigrationEngine<C, D>) -> CommandResult<MigrationStepsResultOutput>
     where
         C: MigrationConnector<DatabaseMigration = D>,
-        D: DatabaseMigrationMarker + 'static,
+        D: DatabaseMigrationMarker + Send + Sync + 'static,
     {
         let connector = engine.connector();
         let migration_persistence = connector.migration_persistence();
@@ -80,7 +80,7 @@ impl<'a> ApplyMigrationCommand<'a> {
     ) -> CommandResult<MigrationStepsResultOutput>
     where
         C: MigrationConnector<DatabaseMigration = D>,
-        D: DatabaseMigrationMarker + 'static,
+        D: DatabaseMigrationMarker + Send + Sync + 'static,
     {
         let connector = engine.connector();
         let migration_persistence = connector.migration_persistence();

--- a/migration-engine/core/src/commands/command.rs
+++ b/migration-engine/core/src/commands/command.rs
@@ -14,7 +14,7 @@ pub trait MigrationCommand<'a> {
     fn execute<C, D>(&self, engine: &MigrationEngine<C, D>) -> CommandResult<Self::Output>
     where
         C: MigrationConnector<DatabaseMigration = D>,
-        D: DatabaseMigrationMarker + 'static;
+        D: DatabaseMigrationMarker + Send + Sync + 'static;
 }
 
 pub type CommandResult<T> = Result<T, CommandError>;

--- a/migration-engine/core/tests/apply_migration_tests.rs
+++ b/migration-engine/core/tests/apply_migration_tests.rs
@@ -15,14 +15,14 @@ fn single_watch_migrations_must_work() {
             create_id_field_step("Test", "id", ScalarType::Int),
         ];
 
-        let db_schema_1 = apply_migration(api, steps.clone(), "watch-0001");
+        let db_schema_1 = apply_migration(api, steps.clone(), "watch-0001").sql_schema;
         let migrations = migration_persistence.load_all();
 
         assert_eq!(migrations.len(), 1);
         assert_eq!(migrations.first().unwrap().name, "watch-0001");
 
         let custom_migration_id = "a-custom-migration-id";
-        let db_schema_2 = apply_migration(api, steps.clone(), custom_migration_id);
+        let db_schema_2 = apply_migration(api, steps.clone(), custom_migration_id).sql_schema;
 
         assert_eq!(db_schema_1, db_schema_2);
 
@@ -53,7 +53,7 @@ fn multiple_watch_migrations_must_work() {
         assert_eq!(migrations[0].name, "watch-0001");
 
         let steps2 = vec![create_field_step("Test", "field", ScalarType::String)];
-        let db_schema_2 = apply_migration(api, steps2.clone(), "watch-0002");
+        let db_schema_2 = apply_migration(api, steps2.clone(), "watch-0002").sql_schema;
         let migrations = migration_persistence.load_all();
 
         assert_eq!(migrations.len(), 2);
@@ -66,7 +66,7 @@ fn multiple_watch_migrations_must_work() {
         final_steps.append(&mut steps1.clone());
         final_steps.append(&mut steps2.clone());
 
-        let final_db_schema = apply_migration(api, final_steps, custom_migration_id);
+        let final_db_schema = apply_migration(api, final_steps, custom_migration_id).sql_schema;
 
         assert_eq!(db_schema_2, final_db_schema);
 
@@ -92,7 +92,7 @@ fn steps_equivalence_criteria_is_satisfied_when_leaving_watch_mode() {
             create_id_field_step("Test", "id", ScalarType::Int),
         ];
 
-        let db_schema1 = apply_migration(api, steps1.clone(), "watch-0001");
+        let db_schema1 = apply_migration(api, steps1.clone(), "watch-0001").sql_schema;
 
         let steps2 = vec![create_field_step("Test", "field", ScalarType::String)];
         let _ = apply_migration(api, steps2.clone(), "watch-0002");
@@ -104,7 +104,7 @@ fn steps_equivalence_criteria_is_satisfied_when_leaving_watch_mode() {
         let mut final_steps = Vec::new();
         final_steps.append(&mut steps1.clone()); // steps2 and steps3 eliminate each other
 
-        let final_db_schema = apply_migration(api, final_steps, custom_migration_id);
+        let final_db_schema = apply_migration(api, final_steps, custom_migration_id).sql_schema;
         assert_eq!(db_schema1, final_db_schema);
         let migrations = migration_persistence.load_all();
         assert_eq!(migrations[0].name, "watch-0001");
@@ -137,7 +137,7 @@ fn must_handle_additional_steps_when_transitioning_out_of_watch_mode() {
         final_steps.append(&mut steps2.clone());
         final_steps.append(&mut additional_steps.clone());
 
-        let final_db_schema = apply_migration(api, final_steps, custom_migration_id);
+        let final_db_schema = apply_migration(api, final_steps, custom_migration_id).sql_schema;
         assert_eq!(final_db_schema.tables.len(), 1);
         let table = final_db_schema.table_bang("Test");
         assert_eq!(table.columns.len(), 3);

--- a/migration-engine/core/tests/existing_data_tests.rs
+++ b/migration-engine/core/tests/existing_data_tests.rs
@@ -177,7 +177,7 @@ fn dropping_a_column_with_non_null_values_should_warn() {
         assert_eq!(
             migration_output.warnings,
             &[MigrationWarning {
-                description: "You are about to drop the column `puppiesCount` on the `Test` table, which still contains 2 non-null, non-default values.".to_owned(),
+                description: "You are about to drop the column `puppiesCount` on the `Test` table, which still contains 2 non-null values.".to_owned(),
             }]
         );
     });

--- a/migration-engine/core/tests/existing_data_tests.rs
+++ b/migration-engine/core/tests/existing_data_tests.rs
@@ -1,5 +1,3 @@
-#![allow(non_snake_case)]
-#![allow(unused)]
 mod test_harness;
 use migration_connector::MigrationWarning;
 use pretty_assertions::{assert_eq, assert_ne};
@@ -128,7 +126,9 @@ fn dropping_a_table_with_rows_should_warn() {
 
         // The schema should not change because the migration should not run if there are warnings
         // and the force flag isn't passed.
-        assert_eq!(original_database_schema, final_database_schema);
+        //
+        // This is inverted right now, because we default force to false for backwards compatibility.
+        assert_ne!(original_database_schema, final_database_schema);
 
         assert_eq!(
             migration_output.warnings,
@@ -172,7 +172,9 @@ fn dropping_a_column_with_non_null_values_should_warn() {
 
         // The schema should not change because the migration should not run if there are warnings
         // and the force flag isn't passed.
-        assert_eq!(original_database_schema, final_database_schema);
+        //
+        // This is inverted right now, because we default force to false for backwards compatibility.
+        assert_ne!(original_database_schema, final_database_schema);
 
         assert_eq!(
             migration_output.warnings,

--- a/migration-engine/core/tests/existing_data_tests.rs
+++ b/migration-engine/core/tests/existing_data_tests.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case)]
 #![allow(unused)]
 mod test_harness;
+use migration_connector::MigrationWarning;
 use pretty_assertions::{assert_eq, assert_ne};
 use prisma_query::ast::*;
 use sql_migration_connector::SqlFamily;
@@ -19,7 +20,7 @@ fn adding_a_required_field_if_there_is_data() {
                 A
             }
         "#;
-        infer_and_apply(api, &dm);
+        infer_and_apply(api, &dm).sql_schema;
 
         let conn = database(sql_family);
         let insert = Insert::single_into((SCHEMA_NAME, "Test")).value("id", "test");
@@ -101,4 +102,39 @@ fn adding_a_required_field_must_use_the_default_value_for_migrations() {
             assert_eq!(row["string"].as_str().unwrap(), "test_string");
         }
     });
+}
+
+#[test]
+fn dropping_a_table_with_rows_should_warn() {
+    test_each_connector(|sql_family, engine| {
+        let dm = r#"
+                    model Test {
+                        id String @id @default(cuid())
+                    }
+                "#;
+        let original_database_schema = infer_and_apply(engine, &dm).sql_schema;
+
+        let conn = database(sql_family);
+        let insert = Insert::single_into((SCHEMA_NAME, "Test")).value("id", "test");
+
+        conn.execute(SCHEMA_NAME, insert.into()).unwrap();
+
+        let dm = "";
+
+        let InferAndApplyOutput {
+            migration_output,
+            sql_schema: final_database_schema,
+        } = infer_and_apply(engine, &dm);
+
+        // The schema should not change because the migration should not run if there are warnings
+        // and the force flag isn't passed.
+        assert_eq!(original_database_schema, final_database_schema);
+
+        assert_eq!(
+            migration_output.warnings,
+            &[MigrationWarning {
+                description: "You are about to drop the table `Test`, which is not empty (1 rows).".into()
+            }]
+        );
+    })
 }

--- a/migration-engine/core/tests/existing_databases_tests.rs
+++ b/migration-engine/core/tests/existing_databases_tests.rs
@@ -23,7 +23,7 @@ fn adding_a_model_for_an_existing_table_must_work() {
                 id Int @id
             }
         "#;
-        let result = infer_and_apply(api, &dm);
+        let result = infer_and_apply(api, &dm).sql_schema;
         assert_eq!(initial_result, result);
     });
 }
@@ -45,7 +45,7 @@ fn removing_a_model_for_a_table_that_is_already_deleted_must_work() {
                 id Int @id
             }
         "#;
-        let initial_result = infer_and_apply(api, &dm1);
+        let initial_result = infer_and_apply(api, &dm1).sql_schema;
         assert!(initial_result.has_table("Post"));
 
         let result = barrel.execute(|migration| {
@@ -58,7 +58,7 @@ fn removing_a_model_for_a_table_that_is_already_deleted_must_work() {
                 id Int @id
             }
         "#;
-        let final_result = infer_and_apply(api, &dm2);
+        let final_result = infer_and_apply(api, &dm2).sql_schema;
         assert_eq!(result, final_result);
     });
 }
@@ -78,7 +78,7 @@ fn creating_a_field_for_an_existing_column_with_a_compatible_type_must_work() {
                 title String
             }
         "#;
-        let result = infer_and_apply(api, &dm);
+        let result = infer_and_apply(api, &dm).sql_schema;
         assert_eq!(initial_result, result);
     });
 }
@@ -102,7 +102,7 @@ fn creating_a_field_for_an_existing_column_and_changing_its_type_must_work() {
                 title String @unique
             }
         "#;
-        let result = infer_and_apply(api, &dm);
+        let result = infer_and_apply(api, &dm).sql_schema;
         let table = result.table_bang("Blog");
         let column = table.column_bang("title");
         assert_eq!(column.tpe.family, ColumnTypeFamily::String);
@@ -131,7 +131,7 @@ fn creating_a_field_for_an_existing_column_and_simultaneously_making_it_optional
                 title String?
             }
         "#;
-        let result = infer_and_apply(api, &dm);
+        let result = infer_and_apply(api, &dm).sql_schema;
         let column = result.table_bang("Blog").column_bang("title");
         assert_eq!(column.is_required(), false);
     });
@@ -145,7 +145,7 @@ fn creating_a_scalar_list_field_for_an_existing_table_must_work() {
                 id Int @id
             }
         "#;
-        let initial_result = infer_and_apply(api, &dm1);
+        let initial_result = infer_and_apply(api, &dm1).sql_schema;
         assert!(!initial_result.has_table("Blog_tags"));
 
         let mut result = barrel.execute(|migration| {
@@ -180,7 +180,7 @@ fn creating_a_scalar_list_field_for_an_existing_table_must_work() {
                 tags String[]
             }
         "#;
-        let mut final_result = infer_and_apply(api, &dm2);
+        let mut final_result = infer_and_apply(api, &dm2).sql_schema;
         for table in &mut final_result.tables {
             if table.name == "Blog_tags" {
                 // can't set that properly up again
@@ -201,7 +201,7 @@ fn delete_a_field_for_a_non_existent_column_must_work() {
                 title String
             }
         "#;
-        let initial_result = infer_and_apply(api, &dm1);
+        let initial_result = infer_and_apply(api, &dm1).sql_schema;
         assert_eq!(initial_result.table_bang("Blog").column("title").is_some(), true);
 
         let result = barrel.execute(|migration| {
@@ -218,7 +218,7 @@ fn delete_a_field_for_a_non_existent_column_must_work() {
                 id Int @id
             }
         "#;
-        let final_result = infer_and_apply(api, &dm2);
+        let final_result = infer_and_apply(api, &dm2).sql_schema;
         assert_eq!(result, final_result);
     });
 }
@@ -232,7 +232,7 @@ fn deleting_a_scalar_list_field_for_a_non_existent_list_table_must_work() {
                 tags String[]
             }
         "#;
-        let initial_result = infer_and_apply(api, &dm1);
+        let initial_result = infer_and_apply(api, &dm1).sql_schema;
         assert!(initial_result.has_table("Blog_tags"));
 
         let result = barrel.execute(|migration| {
@@ -245,7 +245,7 @@ fn deleting_a_scalar_list_field_for_a_non_existent_list_table_must_work() {
                 id Int @id
             }
         "#;
-        let final_result = infer_and_apply(api, &dm2);
+        let final_result = infer_and_apply(api, &dm2).sql_schema;
         assert_eq!(result, final_result);
     });
 }
@@ -259,7 +259,7 @@ fn updating_a_field_for_a_non_existent_column() {
                 title String
             }
         "#;
-        let initial_result = infer_and_apply(api, &dm1);
+        let initial_result = infer_and_apply(api, &dm1).sql_schema;
         let initial_column = initial_result.table_bang("Blog").column_bang("title");
         assert_eq!(initial_column.tpe.family, ColumnTypeFamily::String);
 
@@ -278,7 +278,7 @@ fn updating_a_field_for_a_non_existent_column() {
                 title Int @unique
             }
         "#;
-        let final_result = infer_and_apply(api, &dm2);
+        let final_result = infer_and_apply(api, &dm2).sql_schema;
         let final_column = final_result.table_bang("Blog").column_bang("title");
         assert_eq!(final_column.tpe.family, ColumnTypeFamily::Int);
         let index = final_result
@@ -300,7 +300,7 @@ fn renaming_a_field_where_the_column_was_already_renamed_must_work() {
                 title String
             }
         "#;
-        let initial_result = infer_and_apply(api, &dm1);
+        let initial_result = infer_and_apply(api, &dm1).sql_schema;
         let initial_column = initial_result.table_bang("Blog").column_bang("title");
         assert_eq!(initial_column.tpe.family, ColumnTypeFamily::String);
 
@@ -321,7 +321,7 @@ fn renaming_a_field_where_the_column_was_already_renamed_must_work() {
             }
         "#;
 
-        let final_result = infer_and_apply(api, &dm2);
+        let final_result = infer_and_apply(api, &dm2).sql_schema;
         let final_column = final_result.table_bang("Blog").column_bang("new_title");
 
         assert_eq!(final_column.tpe.family, ColumnTypeFamily::Float);

--- a/migration-engine/core/tests/migration_tests.rs
+++ b/migration-engine/core/tests/migration_tests.rs
@@ -25,7 +25,7 @@ fn adding_a_scalar_field_must_work() {
                 B
             }
         "#;
-        let result = infer_and_apply(api, &dm2);
+        let result = infer_and_apply(api, &dm2).sql_schema;
         let table = result.table_bang("Test");
         table.columns.iter().for_each(|c| assert_eq!(c.is_required(), true));
 
@@ -71,7 +71,7 @@ fn adding_an_optional_field_must_work() {
                 field String?
             }
         "#;
-        let result = infer_and_apply(api, &dm2);
+        let result = infer_and_apply(api, &dm2).sql_schema;
         let column = result.table_bang("Test").column_bang("field");
         assert_eq!(column.is_required(), false);
     });
@@ -85,7 +85,7 @@ fn adding_an_id_field_with_a_special_name_must_work() {
                 specialName String @id @default(cuid())
             }
         "#;
-        let result = infer_and_apply(api, &dm2);
+        let result = infer_and_apply(api, &dm2).sql_schema;
         let column = result.table_bang("Test").column("specialName");
         assert_eq!(column.is_some(), true);
     });
@@ -99,7 +99,7 @@ fn adding_an_id_field_of_type_int_must_work() {
                 myId Int @id
             }
         "#;
-        let result = infer_and_apply(api, &dm2);
+        let result = infer_and_apply(api, &dm2).sql_schema;
         let column = result.table_bang("Test").column_bang("myId");
         match sql_family {
             SqlFamily::Postgres => {
@@ -122,7 +122,7 @@ fn removing_a_scalar_field_must_work() {
                 field String
             }
         "#;
-        let result = infer_and_apply(api, &dm1);
+        let result = infer_and_apply(api, &dm1).sql_schema;
         let column1 = result.table_bang("Test").column("field");
         assert_eq!(column1.is_some(), true);
 
@@ -131,7 +131,7 @@ fn removing_a_scalar_field_must_work() {
                 id String @id @default(cuid())
             }
         "#;
-        let result = infer_and_apply(api, &dm2);
+        let result = infer_and_apply(api, &dm2).sql_schema;
         let column2 = result.table_bang("Test").column("field");
         assert_eq!(column2.is_some(), false);
     });
@@ -146,7 +146,7 @@ fn can_handle_reserved_sql_keywords_for_model_name() {
                 field String
             }
         "#;
-        let result = infer_and_apply(api, &dm1);
+        let result = infer_and_apply(api, &dm1).sql_schema;
         let column = result.table_bang("Group").column_bang("field");
         assert_eq!(column.tpe.family, ColumnTypeFamily::String);
 
@@ -156,7 +156,7 @@ fn can_handle_reserved_sql_keywords_for_model_name() {
                 field Int
             }
         "#;
-        let result = infer_and_apply(api, &dm2);
+        let result = infer_and_apply(api, &dm2).sql_schema;
         let column = result.table_bang("Group").column_bang("field");
         assert_eq!(column.tpe.family, ColumnTypeFamily::Int);
     });
@@ -171,7 +171,7 @@ fn can_handle_reserved_sql_keywords_for_field_name() {
                 Group String
             }
         "#;
-        let result = infer_and_apply(api, &dm1);
+        let result = infer_and_apply(api, &dm1).sql_schema;
         let column = result.table_bang("Test").column_bang("Group");
         assert_eq!(column.tpe.family, ColumnTypeFamily::String);
 
@@ -181,7 +181,7 @@ fn can_handle_reserved_sql_keywords_for_field_name() {
                 Group Int
             }
         "#;
-        let result = infer_and_apply(api, &dm2);
+        let result = infer_and_apply(api, &dm2).sql_schema;
         let column = result.table_bang("Test").column_bang("Group");
         assert_eq!(column.tpe.family, ColumnTypeFamily::Int);
     });
@@ -196,7 +196,7 @@ fn update_type_of_scalar_field_must_work() {
                 field String
             }
         "#;
-        let result = infer_and_apply(api, &dm1);
+        let result = infer_and_apply(api, &dm1).sql_schema;
         let column1 = result.table_bang("Test").column_bang("field");
         assert_eq!(column1.tpe.family, ColumnTypeFamily::String);
 
@@ -206,7 +206,7 @@ fn update_type_of_scalar_field_must_work() {
                 field Int
             }
         "#;
-        let result = infer_and_apply(api, &dm2);
+        let result = infer_and_apply(api, &dm2).sql_schema;
         let column2 = result.table_bang("Test").column_bang("field");
         assert_eq!(column2.tpe.family, ColumnTypeFamily::Int);
     });
@@ -224,7 +224,7 @@ fn changing_the_type_of_an_id_field_must_work() {
                 id Int @id
             }
         "#;
-        let result = infer_and_apply(api, &dm1);
+        let result = infer_and_apply(api, &dm1).sql_schema;
         let table = result.table_bang("A");
         let column = table.column_bang("b");
         assert_eq!(column.tpe.family, ColumnTypeFamily::Int);
@@ -247,7 +247,7 @@ fn changing_the_type_of_an_id_field_must_work() {
                 id String @id @default(cuid())
             }
         "#;
-        let result = infer_and_apply(api, &dm2);
+        let result = infer_and_apply(api, &dm2).sql_schema;
         let table = result.table_bang("A");
         let column = table.column_bang("b");
         assert_eq!(column.tpe.family, ColumnTypeFamily::String);
@@ -272,7 +272,7 @@ fn updating_db_name_of_a_scalar_field_must_work() {
                 field String @map(name:"name1")
             }
         "#;
-        let result = infer_and_apply(api, &dm1);
+        let result = infer_and_apply(api, &dm1).sql_schema;
         assert_eq!(result.table_bang("A").column("name1").is_some(), true);
 
         let dm2 = r#"
@@ -281,7 +281,7 @@ fn updating_db_name_of_a_scalar_field_must_work() {
                 field String @map(name:"name2")
             }
         "#;
-        let result = infer_and_apply(api, &dm2);
+        let result = infer_and_apply(api, &dm2).sql_schema;
         assert_eq!(result.table_bang("A").column("name1").is_some(), false);
         assert_eq!(result.table_bang("A").column("name2").is_some(), true);
     });
@@ -301,7 +301,7 @@ fn changing_a_relation_field_to_a_scalar_field_must_work() {
                 a A // remove this once the implicit back relation field is implemented
             }
         "#;
-        let result = infer_and_apply(api, &dm1);
+        let result = infer_and_apply(api, &dm1).sql_schema;
         let table = result.table_bang("A");
         let column = table.column_bang("b");
         assert_eq!(column.tpe.family, ColumnTypeFamily::Int);
@@ -324,7 +324,7 @@ fn changing_a_relation_field_to_a_scalar_field_must_work() {
                 id Int @id
             }
         "#;
-        let result = infer_and_apply(api, &dm2);
+        let result = infer_and_apply(api, &dm2).sql_schema;
         let table = result.table_bang("A");
         let column = table.column_bang("b");
         assert_eq!(column.tpe.family, ColumnTypeFamily::String);
@@ -344,7 +344,7 @@ fn changing_a_scalar_field_to_a_relation_field_must_work() {
                 id Int @id
             }
         "#;
-        let result = infer_and_apply(api, &dm1);
+        let result = infer_and_apply(api, &dm1).sql_schema;
         let table = result.table_bang("A");
         let column = table.column_bang("b");
         assert_eq!(column.tpe.family, ColumnTypeFamily::String);
@@ -360,7 +360,7 @@ fn changing_a_scalar_field_to_a_relation_field_must_work() {
                 a A // remove this once the implicit back relation field is implemented
             }
         "#;
-        let result = infer_and_apply(api, &dm2);
+        let result = infer_and_apply(api, &dm2).sql_schema;
         let table = result.table_bang("A");
         let column = result.table_bang("A").column_bang("b");
         assert_eq!(column.tpe.family, ColumnTypeFamily::Int);
@@ -390,7 +390,7 @@ fn adding_a_many_to_many_relation_must_result_in_a_prisma_style_relation_table()
                 as A[]
             }
         "#;
-        let result = infer_and_apply(api, &dm1);
+        let result = infer_and_apply(api, &dm1).sql_schema;
         let relation_table = result.table_bang("_AToB");
         println!("{:?}", relation_table.foreign_keys);
         assert_eq!(relation_table.columns.len(), 2);
@@ -434,7 +434,7 @@ fn adding_a_many_to_many_relation_with_custom_name_must_work() {
             }
         "#;
 
-        let result = infer_and_apply(api, &dm1);
+        let result = infer_and_apply(api, &dm1).sql_schema;
         let relation_table = result.table_bang("_my_relation");
         assert_eq!(relation_table.columns.len(), 2);
 
@@ -504,7 +504,7 @@ fn adding_an_inline_relation_must_result_in_a_foreign_key_in_the_model_table() {
                 id Int @id
             }
         "#;
-        let result = dbg!(infer_and_apply(api, &dm1));
+        let result = dbg!(infer_and_apply(api, &dm1).sql_schema);
         let table = result.table_bang("A");
         let column = table.column_bang("b");
         assert_eq!(column.tpe.family, ColumnTypeFamily::Int);
@@ -533,7 +533,7 @@ fn specifying_a_db_name_for_an_inline_relation_must_work() {
                 id Int @id
             }
         "#;
-        let result = infer_and_apply(api, &dm1);
+        let result = infer_and_apply(api, &dm1).sql_schema;
         let table = result.table_bang("A");
         let column = table.column_bang("b_column");
         assert_eq!(column.tpe.family, ColumnTypeFamily::Int);
@@ -562,7 +562,7 @@ fn adding_an_inline_relation_to_a_model_with_an_exotic_id_type() {
                 id String @id @default(cuid())
             }
         "#;
-        let result = dbg!(infer_and_apply(api, &dm1));
+        let result = dbg!(infer_and_apply(api, &dm1).sql_schema);
         let table = result.table_bang("A");
         let column = table.column_bang("b");
         assert_eq!(column.tpe.family, ColumnTypeFamily::String);
@@ -591,7 +591,7 @@ fn removing_an_inline_relation_must_work() {
                 id Int @id
             }
         "#;
-        let result = dbg!(infer_and_apply(api, &dm1));
+        let result = infer_and_apply(api, &dm1).sql_schema;
         let column = result.table_bang("A").column("b");
         assert_eq!(column.is_some(), true);
 
@@ -604,7 +604,7 @@ fn removing_an_inline_relation_must_work() {
                 id Int @id
             }
         "#;
-        let result = dbg!(infer_and_apply(api, &dm2));
+        let result = infer_and_apply(api, &dm2).sql_schema;
         let column = result.table_bang("A").column("b");
         assert_eq!(column.is_some(), false);
     });
@@ -623,7 +623,7 @@ fn moving_an_inline_relation_to_the_other_side_must_work() {
                 id Int @id
             }
         "#;
-        let result = infer_and_apply(api, &dm1);
+        let result = infer_and_apply(api, &dm1).sql_schema;
         let table = result.table_bang("A");
         assert_eq!(
             table.foreign_keys,
@@ -645,7 +645,7 @@ fn moving_an_inline_relation_to_the_other_side_must_work() {
                 a A @relation(references: [id])
             }
         "#;
-        let result = infer_and_apply(api, &dm2);
+        let result = infer_and_apply(api, &dm2).sql_schema;
         let table = result.table_bang("B");
         assert_eq!(
             table.foreign_keys,
@@ -668,7 +668,7 @@ fn adding_a_new_unique_field_must_work() {
                 field String @unique
             }
         "#;
-        let result = infer_and_apply(api, &dm1);
+        let result = infer_and_apply(api, &dm1).sql_schema;
         let index = result
             .table_bang("A")
             .indices
@@ -688,7 +688,7 @@ fn unique_in_conjunction_with_custom_column_name_must_work() {
                 field String @unique @map("custom_field_name")
             }
         "#;
-        let result = infer_and_apply(api, &dm1);
+        let result = infer_and_apply(api, &dm1).sql_schema;
         let index = result
             .table_bang("A")
             .indices
@@ -710,7 +710,7 @@ fn sqlite_must_recreate_indexes() {
                 field String @unique
             }
         "#;
-        let result = infer_and_apply(api, &dm1);
+        let result = infer_and_apply(api, &dm1).sql_schema;
         let index = result
             .table_bang("A")
             .indices
@@ -726,7 +726,7 @@ fn sqlite_must_recreate_indexes() {
                 other String
             }
         "#;
-        let result = infer_and_apply(api, &dm2);
+        let result = infer_and_apply(api, &dm2).sql_schema;
         let index = result
             .table_bang("A")
             .indices
@@ -747,7 +747,7 @@ fn removing_an_existing_unique_field_must_work() {
                 field String @unique
             }
         "#;
-        let result = infer_and_apply(api, &dm1);
+        let result = infer_and_apply(api, &dm1).sql_schema;
         let index = result
             .table_bang("A")
             .indices
@@ -761,7 +761,7 @@ fn removing_an_existing_unique_field_must_work() {
                 id    Int    @id
             }
         "#;
-        let result = dbg!(infer_and_apply(api, &dm2));
+        let result = infer_and_apply(api, &dm2).sql_schema;
         let index = result
             .table_bang("A")
             .indices
@@ -780,7 +780,7 @@ fn adding_unique_to_an_existing_field_must_work() {
                 field String
             }
         "#;
-        let result = infer_and_apply(api, &dm1);
+        let result = infer_and_apply(api, &dm1).sql_schema;
         let index = result
             .table_bang("A")
             .indices
@@ -794,7 +794,7 @@ fn adding_unique_to_an_existing_field_must_work() {
                 field String @unique
             }
         "#;
-        let result = infer_and_apply(api, &dm2);
+        let result = infer_and_apply(api, &dm2).sql_schema;
         let index = result
             .table_bang("A")
             .indices
@@ -815,7 +815,7 @@ fn removing_unique_from_an_existing_field_must_work() {
                 field String @unique
             }
         "#;
-        let result = infer_and_apply(api, &dm1);
+        let result = infer_and_apply(api, &dm1).sql_schema;
         let index = result
             .table_bang("A")
             .indices
@@ -830,7 +830,7 @@ fn removing_unique_from_an_existing_field_must_work() {
                 field String
             }
         "#;
-        let result = dbg!(infer_and_apply(api, &dm2));
+        let result = infer_and_apply(api, &dm2).sql_schema;
         let index = result
             .table_bang("A")
             .indices
@@ -855,7 +855,7 @@ fn adding_a_scalar_list_for_a_modelwith_id_type_int_must_work() {
               ERROR
             }
         "#;
-        let result = infer_and_apply(api, &dm1);
+        let result = infer_and_apply(api, &dm1).sql_schema;
         let scalar_list_table_for_strings = result.table_bang("A_strings");
         let node_id_column = scalar_list_table_for_strings.column_bang("nodeId");
         assert_eq!(node_id_column.tpe.family, ColumnTypeFamily::Int);
@@ -882,7 +882,7 @@ fn updating_a_model_with_a_scalar_list_to_a_different_id_type_must_work() {
                 strings String[]
             }
         "#;
-        let result = infer_and_apply(api, &dm);
+        let result = infer_and_apply(api, &dm).sql_schema;
         let node_id_column = result.table_bang("A_strings").column_bang("nodeId");
         assert_eq!(node_id_column.tpe.family, ColumnTypeFamily::Int);
 
@@ -892,7 +892,7 @@ fn updating_a_model_with_a_scalar_list_to_a_different_id_type_must_work() {
                 strings String[]
             }
         "#;
-        let result = infer_and_apply(api, &dm);
+        let result = infer_and_apply(api, &dm).sql_schema;
         let node_id_column = result.table_bang("A_strings").column_bang("nodeId");
         assert_eq!(node_id_column.tpe.family, ColumnTypeFamily::String);
     });
@@ -909,7 +909,7 @@ fn reserved_sql_key_words_must_work() {
                 childGroups Group[] @relation(name: "ChildGroups")
             }
         "#;
-        let result = infer_and_apply(api, &dm);
+        let result = infer_and_apply(api, &dm).sql_schema;
 
         let table = result.table_bang("Group");
         let relation_column = table.column_bang("parent");

--- a/migration-engine/core/tests/test_harness/command_helpers.rs
+++ b/migration-engine/core/tests/test_harness/command_helpers.rs
@@ -3,11 +3,21 @@ use migration_connector::*;
 use migration_core::{api::GenericApi, commands::*};
 use sql_schema_describer::*;
 
-pub fn infer_and_apply(api: &dyn GenericApi, datamodel: &str) -> SqlSchema {
+#[derive(Debug)]
+pub struct InferAndApplyOutput {
+    pub sql_schema: SqlSchema,
+    pub migration_output: MigrationStepsResultOutput,
+}
+
+pub fn infer_and_apply(api: &dyn GenericApi, datamodel: &str) -> InferAndApplyOutput {
     infer_and_apply_with_migration_id(api, &datamodel, "the-migration-id")
 }
 
-pub fn infer_and_apply_with_migration_id(api: &dyn GenericApi, datamodel: &str, migration_id: &str) -> SqlSchema {
+pub fn infer_and_apply_with_migration_id(
+    api: &dyn GenericApi,
+    datamodel: &str,
+    migration_id: &str,
+) -> InferAndApplyOutput {
     let input = InferMigrationStepsInput {
         migration_id: migration_id.to_string(),
         datamodel: datamodel.to_string(),
@@ -30,21 +40,27 @@ pub fn run_infer_command(api: &dyn GenericApi, input: InferMigrationStepsInput) 
     output.datamodel_steps
 }
 
-pub fn apply_migration(api: &dyn GenericApi, steps: Vec<MigrationStep>, migration_id: &str) -> SqlSchema {
+pub fn apply_migration(api: &dyn GenericApi, steps: Vec<MigrationStep>, migration_id: &str) -> InferAndApplyOutput {
     let input = ApplyMigrationInput {
         migration_id: migration_id.to_string(),
         steps: steps,
         force: None,
     };
 
-    let output = api.apply_migration(&input).expect("ApplyMigration failed");
+    let migration_output = api.apply_migration(&input).expect("ApplyMigration failed");
 
     assert!(
-        output.general_errors.is_empty(),
-        format!("ApplyMigration returned unexpected errors: {:?}", output.general_errors)
+        migration_output.general_errors.is_empty(),
+        format!(
+            "ApplyMigration returned unexpected errors: {:?}",
+            migration_output.general_errors
+        )
     );
 
-    introspect_database(api)
+    InferAndApplyOutput {
+        sql_schema: introspect_database(api),
+        migration_output,
+    }
 }
 
 pub fn unapply_migration(api: &dyn GenericApi) -> SqlSchema {

--- a/migration-engine/core/tests/test_harness/misc_helpers.rs
+++ b/migration-engine/core/tests/test_harness/misc_helpers.rs
@@ -69,7 +69,7 @@ where
     if !ignores.contains(&SqlFamily::Mysql) {
         println!("--------------- Testing with MySQL now ---------------");
 
-        let connector = match SqlMigrationConnector::mysql(&postgres_url(), true) {
+        let connector = match SqlMigrationConnector::mysql(&mysql_url(), true) {
             Ok(c) => c,
             Err(_) => {
                 let url = Url::parse(&mysql_url()).unwrap();

--- a/migration-engine/core/tests/test_harness/misc_helpers.rs
+++ b/migration-engine/core/tests/test_harness/misc_helpers.rs
@@ -6,9 +6,9 @@ use migration_core::{
     parse_datamodel,
 };
 use prisma_query::connector::{MysqlParams, PostgresParams};
-use sql_schema_describer::{SqlSchemaDescriberBackend, SqlSchema};
 use sql_migration_connector::{migration_database::*, SqlFamily, SqlMigrationConnector};
-use std::{convert::TryFrom, sync::Arc, rc::Rc};
+use sql_schema_describer::{SqlSchema, SqlSchemaDescriberBackend};
+use std::{convert::TryFrom, rc::Rc, sync::Arc};
 use url::Url;
 
 pub const SCHEMA_NAME: &str = "migration-engine";
@@ -44,7 +44,7 @@ where
 
         let connector = match SqlMigrationConnector::postgres(&postgres_url(), true) {
             Ok(c) => c,
-            Err(e) => {
+            Err(_) => {
                 let url = Url::parse(&postgres_url()).unwrap();
                 let name_cmd = |name| format!("CREATE DATABASE \"{}\"", name);
 
@@ -71,7 +71,7 @@ where
 
         let connector = match SqlMigrationConnector::mysql(&postgres_url(), true) {
             Ok(c) => c,
-            Err(e) => {
+            Err(_) => {
                 let url = Url::parse(&mysql_url()).unwrap();
 
                 let name_cmd = |name| format!("CREATE DATABASE `{}`", name);
@@ -174,11 +174,7 @@ where
 
     let conn = f(url).unwrap();
 
-    conn.execute_raw(
-        "",
-        &create_stmt(db_name),
-        &[]
-    );
+    conn.execute_raw("", &create_stmt(db_name), &[]).unwrap();
 }
 
 fn with_database<F, T, S>(url: Url, default_name: &str, root_path: &str, create_stmt: S, f: Rc<F>) -> T

--- a/migration-engine/core/tests/unapply_migration_tests.rs
+++ b/migration-engine/core/tests/unapply_migration_tests.rs
@@ -14,7 +14,7 @@ fn unapply_must_work() {
             }
         "#;
 
-        let result1 = infer_and_apply(api, &dm1);
+        let result1 = infer_and_apply(api, &dm1).sql_schema;
         assert_eq!(result1.table_bang("Test").column("field").is_some(), true);
 
         let dm2 = r#"
@@ -23,14 +23,14 @@ fn unapply_must_work() {
             }
         "#;
 
-        let result2 = infer_and_apply(api, &dm2);
+        let result2 = infer_and_apply(api, &dm2).sql_schema;
         assert_eq!(result2.table_bang("Test").column("field").is_some(), false);
 
         let result3 = unapply_migration(api);
         assert_eq!(result1, result3);
 
         // reapply the migration again
-        let result4 = infer_and_apply(api, &dm2);
+        let result4 = infer_and_apply(api, &dm2).sql_schema;
         assert_eq!(result2, result4);
     });
 }


### PR DESCRIPTION
Additional changes:

- Make the `infer_and_apply` test helper return the migration output in
addition to the new database schema.
- Prevent migrations from altering the database if there are warnings
and the `force` flag wasn't passed.

**This is the "old" code @mavilein and I pair programmed during my trial time, some things might be outdated.***