### PR TITLE
Improve migration engine errors on RPC initialization panic

### DIFF
--- a/migration-engine/core/src/main.rs
+++ b/migration-engine/core/src/main.rs
@@ -149,7 +149,7 @@ fn main() {
                     pretty_print_errors(errors, &datamodel);
                     std::process::exit(1);
                 }
-                Err(e) => panic!(e),
+                Err(e) => panic!("{:?}", e),
             }
         }
     }


### PR DESCRIPTION
Tiny fix.

Before:

```
tom-prisma.tom.~/src/mysql-conn λ migration-engine --datamodel datamodel.prisma
thread 'main' panicked at 'Box<Any>', migration-engine/core/src/main.rs:152:27
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
```

After:

```
tom-prisma.tom.~/src/mysql-conn λ migration-engine --datamodel datamodel.prisma
thread 'main' panicked at 'CommandError(Generic { code: 1000, error: "QueryError(QueryError(MySqlError { ERROR 1102 (42000): Incorrect database name \'\' }))" })', migration-engine/core/src/main.rs:152:27
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
```