### PR TITLE
Fix MySQL SqlSchemaDescriber on MySQL 8

### DIFF
--- a/docker-compose/dev-mysql-8.yml
+++ b/docker-compose/dev-mysql-8.yml
@@ -1,4 +1,4 @@
-# Transient db - will lose it's data once restarted
+# Transient db - will lose its data once restarted
 version: "3"
 services:
   mysql8:

--- a/docker-compose/dev-mysql-8.yml
+++ b/docker-compose/dev-mysql-8.yml
@@ -1,0 +1,12 @@
+# Transient db - will lose it's data once restarted
+version: "3"
+services:
+  mysql8:
+    container_name: mysql8
+    image: mysql:8
+    restart: always
+    command: mysqld
+    environment:
+      MYSQL_ROOT_PASSWORD: prisma
+    ports:
+      - "127.0.0.1:3307:3306"

--- a/docker-compose/dev-mysql.yml
+++ b/docker-compose/dev-mysql.yml
@@ -1,4 +1,4 @@
-# Transient db - will lose it's data once restarted
+# Transient db - will lose its data once restarted
 version: "3"
 services:
   mysql:

--- a/docker-compose/dev-postgres.yml
+++ b/docker-compose/dev-postgres.yml
@@ -1,4 +1,4 @@
-# Transient db - will lose it's data once restarted
+# Transient db - will lose its data once restarted
 version: "3"
 services:
   postgres:

--- a/libs/sql-schema-describer/src/mysql.rs
+++ b/libs/sql-schema-describer/src/mysql.rs
@@ -72,7 +72,11 @@ impl SqlSchemaDescriber {
     }
 
     fn get_columns(&self, schema: &str, table: &str) -> Vec<Column> {
-        let sql = "SELECT column_name, data_type, column_default, is_nullable, extra
+        // We alias all the columns because MySQL column names are case-insensitive in queries, but the
+        // information schema column names became upper-case in MySQL 8, causing the code fetching
+        // the result values by column name below to fail.
+        let sql = "
+            SELECT column_name column_name, data_type data_type, column_default column_default, is_nullable is_nullable, extra extra
             FROM information_schema.columns
             WHERE table_schema = ? AND table_name = ?
             ORDER BY column_name";
@@ -134,8 +138,18 @@ impl SqlSchemaDescriber {
         // One should think it's unique since it's used to join information_schema.key_column_usage
         // and information_schema.referential_constraints tables in this query lifted from
         // Stack Overflow
-        let sql = "SELECT kcu.constraint_name, kcu.column_name, kcu.referenced_table_name,
-            kcu.referenced_column_name, kcu.ordinal_position, rc.delete_rule
+        //
+        // We alias all the columns because MySQL column names are case-insensitive in queries, but the
+        // information schema column names became upper-case in MySQL 8, causing the code fetching
+        // the result values by column name below to fail.
+        let sql = "
+            SELECT
+                kcu.constraint_name constraint_name,
+                kcu.column_name column_name,
+                kcu.referenced_table_name referenced_table_name,
+                kcu.referenced_column_name referenced_column_name,
+                kcu.ordinal_position ordinal_position,
+                rc.delete_rule delete_rule
             FROM information_schema.key_column_usage AS kcu
             INNER JOIN information_schema.referential_constraints AS rc ON
             kcu.constraint_name = rc.constraint_name
@@ -232,9 +246,15 @@ impl SqlSchemaDescriber {
         table_name: &str,
         foreign_keys: &[ForeignKey],
     ) -> (Vec<Index>, Option<PrimaryKey>) {
+        // We alias all the columns because MySQL column names are case-insensitive in queries, but the
+        // information schema column names became upper-case in MySQL 8, causing the code fetching
+        // the result values by column name below to fail.
         let sql = "
             SELECT DISTINCT
-                index_name, non_unique, column_name, seq_in_index
+                index_name AS index_name,
+                non_unique AS non_unique,
+                column_name AS column_name,
+                seq_in_index AS seq_in_index
             FROM INFORMATION_SCHEMA.STATISTICS
             WHERE table_schema = ? AND table_name = ?
             ORDER BY index_name, seq_in_index

--- a/libs/sql-schema-describer/src/mysql.rs
+++ b/libs/sql-schema-describer/src/mysql.rs
@@ -80,6 +80,7 @@ impl SqlSchemaDescriber {
             FROM information_schema.columns
             WHERE table_schema = ? AND table_name = ?
             ORDER BY column_name";
+
         let rows = self
             .conn
             .query_raw(sql, schema, &[schema.into(), table.into()])
@@ -88,6 +89,7 @@ impl SqlSchemaDescriber {
             .into_iter()
             .map(|col| {
                 debug!("Got column: {:?}", col);
+
                 let data_type = col.get("data_type").and_then(|x| x.to_string()).expect("get data_type");
                 let is_nullable = col
                     .get("is_nullable")

--- a/libs/sql-schema-describer/tests/mysql/mod.rs
+++ b/libs/sql-schema-describer/tests/mysql/mod.rs
@@ -22,7 +22,7 @@ impl crate::SqlConnection for MySqlConnection {
 
 pub fn get_mysql_describer(sql: &str) -> mysql::SqlSchemaDescriber {
     let host = match std::env::var("IS_BUILDKITE") {
-        Ok(_) => "test-db-mysql",
+        Ok(_) => "test-db-mysql-5-7",
         Err(_) => "127.0.0.1",
     };
     let port = 3306;

--- a/migration-engine/core/src/cli.rs
+++ b/migration-engine/core/src/cli.rs
@@ -198,7 +198,7 @@ mod tests {
 
     fn mysql_url(db: Option<&str>) -> String {
         match std::env::var("IS_BUILDKITE") {
-            Ok(_) => format!("mysql://root:prisma@test-db-mysql:3306/{}", db.unwrap_or("")),
+            Ok(_) => format!("mysql://root:prisma@test-db-mysql-5-7:3306/{}", db.unwrap_or("")),
             _ => format!("mysql://root:prisma@127.0.0.1:3306/{}", db.unwrap_or("")),
         }
     }

--- a/migration-engine/core/tests/apply_migration_tests.rs
+++ b/migration-engine/core/tests/apply_migration_tests.rs
@@ -38,6 +38,73 @@ fn single_watch_migrations_must_work() {
 
 #[test]
 fn multiple_watch_migrations_must_work() {
+    // // std::env::set_var("RUST_LOG", "debug");
+    // // env_logger::init();
+
+    // use std::fmt::Write;
+    // let mut vars = String::new();
+    // for (k, v) in std::env::vars() {
+    //     writeln!(vars, "{}={}", k, v).unwrap();
+    // }
+
+    // for _ in 1..5 {
+    //     println!("===========================");
+    // }
+
+    // let out = std::process::Command::new("docker").arg("ps").output().unwrap();
+    // println!("=== stdout ===");
+    // println!("{}", String::from_utf8_lossy(&out.stdout));
+    // println!("=== stderr ===");
+    // println!("{}", String::from_utf8_lossy(&out.stderr));
+
+    // for _ in 1..5 {
+    //     println!("===========================");
+    // }
+
+    // println!("docker network\n");
+
+    // let out = std::process::Command::new("docker")
+    //     .arg("network")
+    //     .arg("ls")
+    //     .output()
+    //     .unwrap();
+    // println!("=== stdout ===");
+    // println!("{}", String::from_utf8_lossy(&out.stdout));
+    // println!("=== stderr ===");
+    // println!("{}", String::from_utf8_lossy(&out.stderr));
+
+    // for _ in 1..5 {
+    //     println!("===========================");
+    // }
+
+    // let out = std::process::Command::new("docker")
+    //     .arg("network")
+    //     .arg("ls")
+    //     .output()
+    //     .unwrap();
+    // println!("=== stdout ===");
+    // println!("{}", String::from_utf8_lossy(&out.stdout));
+    // println!("=== stderr ===");
+    // println!("{}", String::from_utf8_lossy(&out.stderr));
+
+    // for _ in 1..5 {
+    //     println!("===========================");
+    // }
+
+    // println!("docker network inspect\n");
+
+    // let out = std::process::Command::new("docker")
+    //     .arg("network")
+    //     .arg("inspect")
+    //     .arg("docker-test-setups_tests")
+    //     .output()
+    //     .unwrap();
+    // println!("=== stdout ===");
+    // println!("{}", String::from_utf8_lossy(&out.stdout));
+    // println!("=== stderr ===");
+    // println!("{}", String::from_utf8_lossy(&out.stderr));
+
+    // panic!("{}", vars);
     test_each_connector(|test_setup, api| {
         let migration_persistence = api.migration_persistence();
 

--- a/migration-engine/core/tests/apply_migration_tests.rs
+++ b/migration-engine/core/tests/apply_migration_tests.rs
@@ -7,7 +7,7 @@ use test_harness::*;
 
 #[test]
 fn single_watch_migrations_must_work() {
-    test_each_connector(|_, api| {
+    test_each_connector(|test_setup, api| {
         let migration_persistence = api.migration_persistence();
 
         let steps = vec![
@@ -15,14 +15,14 @@ fn single_watch_migrations_must_work() {
             create_id_field_step("Test", "id", ScalarType::Int),
         ];
 
-        let db_schema_1 = apply_migration(api, steps.clone(), "watch-0001").sql_schema;
+        let db_schema_1 = apply_migration(test_setup, api, steps.clone(), "watch-0001").sql_schema;
         let migrations = migration_persistence.load_all();
 
         assert_eq!(migrations.len(), 1);
         assert_eq!(migrations.first().unwrap().name, "watch-0001");
 
         let custom_migration_id = "a-custom-migration-id";
-        let db_schema_2 = apply_migration(api, steps.clone(), custom_migration_id).sql_schema;
+        let db_schema_2 = apply_migration(test_setup, api, steps.clone(), custom_migration_id).sql_schema;
 
         assert_eq!(db_schema_1, db_schema_2);
 
@@ -38,7 +38,7 @@ fn single_watch_migrations_must_work() {
 
 #[test]
 fn multiple_watch_migrations_must_work() {
-    test_each_connector(|_, api| {
+    test_each_connector(|test_setup, api| {
         let migration_persistence = api.migration_persistence();
 
         let steps1 = vec![
@@ -46,14 +46,14 @@ fn multiple_watch_migrations_must_work() {
             create_id_field_step("Test", "id", ScalarType::Int),
         ];
 
-        let _ = apply_migration(api, steps1.clone(), "watch-0001");
+        let _ = apply_migration(test_setup, api, steps1.clone(), "watch-0001");
         let migrations = migration_persistence.load_all();
 
         assert_eq!(migrations.len(), 1);
         assert_eq!(migrations[0].name, "watch-0001");
 
         let steps2 = vec![create_field_step("Test", "field", ScalarType::String)];
-        let db_schema_2 = apply_migration(api, steps2.clone(), "watch-0002").sql_schema;
+        let db_schema_2 = apply_migration(test_setup, api, steps2.clone(), "watch-0002").sql_schema;
         let migrations = migration_persistence.load_all();
 
         assert_eq!(migrations.len(), 2);
@@ -66,7 +66,7 @@ fn multiple_watch_migrations_must_work() {
         final_steps.append(&mut steps1.clone());
         final_steps.append(&mut steps2.clone());
 
-        let final_db_schema = apply_migration(api, final_steps, custom_migration_id).sql_schema;
+        let final_db_schema = apply_migration(test_setup, api, final_steps, custom_migration_id).sql_schema;
 
         assert_eq!(db_schema_2, final_db_schema);
 
@@ -84,7 +84,7 @@ fn multiple_watch_migrations_must_work() {
 
 #[test]
 fn steps_equivalence_criteria_is_satisfied_when_leaving_watch_mode() {
-    test_each_connector(|_, api| {
+    test_each_connector(|test_setup, api| {
         let migration_persistence = api.migration_persistence();
 
         let steps1 = vec![
@@ -92,19 +92,19 @@ fn steps_equivalence_criteria_is_satisfied_when_leaving_watch_mode() {
             create_id_field_step("Test", "id", ScalarType::Int),
         ];
 
-        let db_schema1 = apply_migration(api, steps1.clone(), "watch-0001").sql_schema;
+        let db_schema1 = apply_migration(test_setup, api, steps1.clone(), "watch-0001").sql_schema;
 
         let steps2 = vec![create_field_step("Test", "field", ScalarType::String)];
-        let _ = apply_migration(api, steps2.clone(), "watch-0002");
+        let _ = apply_migration(test_setup, api, steps2.clone(), "watch-0002");
 
         let steps3 = vec![delete_field_step("Test", "field")];
-        let _ = apply_migration(api, steps3.clone(), "watch-0003");
+        let _ = apply_migration(test_setup, api, steps3.clone(), "watch-0003");
 
         let custom_migration_id = "a-custom-migration-id";
         let mut final_steps = Vec::new();
         final_steps.append(&mut steps1.clone()); // steps2 and steps3 eliminate each other
 
-        let final_db_schema = apply_migration(api, final_steps, custom_migration_id).sql_schema;
+        let final_db_schema = apply_migration(test_setup, api, final_steps, custom_migration_id).sql_schema;
         assert_eq!(db_schema1, final_db_schema);
         let migrations = migration_persistence.load_all();
         assert_eq!(migrations[0].name, "watch-0001");
@@ -116,7 +116,7 @@ fn steps_equivalence_criteria_is_satisfied_when_leaving_watch_mode() {
 
 #[test]
 fn must_handle_additional_steps_when_transitioning_out_of_watch_mode() {
-    test_each_connector(|_, api| {
+    test_each_connector(|test_setup, api| {
         let migration_persistence = api.migration_persistence();
 
         let steps1 = vec![
@@ -124,10 +124,10 @@ fn must_handle_additional_steps_when_transitioning_out_of_watch_mode() {
             create_id_field_step("Test", "id", ScalarType::Int),
         ];
 
-        let _ = apply_migration(api, steps1.clone(), "watch-0001");
+        let _ = apply_migration(test_setup, api, steps1.clone(), "watch-0001");
 
         let steps2 = vec![create_field_step("Test", "field1", ScalarType::String)];
-        let _ = apply_migration(api, steps2.clone(), "watch-0002");
+        let _ = apply_migration(test_setup, api, steps2.clone(), "watch-0002");
 
         let custom_migration_id = "a-custom-migration-id";
         let additional_steps = vec![create_field_step("Test", "field2", ScalarType::String)];
@@ -137,7 +137,7 @@ fn must_handle_additional_steps_when_transitioning_out_of_watch_mode() {
         final_steps.append(&mut steps2.clone());
         final_steps.append(&mut additional_steps.clone());
 
-        let final_db_schema = apply_migration(api, final_steps, custom_migration_id).sql_schema;
+        let final_db_schema = apply_migration(test_setup, api, final_steps, custom_migration_id).sql_schema;
         assert_eq!(final_db_schema.tables.len(), 1);
         let table = final_db_schema.table_bang("Test");
         assert_eq!(table.columns.len(), 3);

--- a/migration-engine/core/tests/existing_databases_tests.rs
+++ b/migration-engine/core/tests/existing_databases_tests.rs
@@ -381,7 +381,7 @@ where
 }
 
 fn get_sqlite() -> (Arc<dyn SqlSchemaDescriberBackend>, Arc<dyn MigrationDatabase>) {
-    let wrapper = database_wrapper(SqlFamily::Sqlite);
+    let wrapper = database_wrapper(SqlFamily::Sqlite, &sqlite_test_file());
     let database = Arc::clone(&wrapper.database);
 
     let database_file_path = sqlite_test_file();
@@ -393,7 +393,7 @@ fn get_sqlite() -> (Arc<dyn SqlSchemaDescriberBackend>, Arc<dyn MigrationDatabas
 }
 
 fn get_postgres() -> (Arc<dyn SqlSchemaDescriberBackend>, Arc<dyn MigrationDatabase>) {
-    let wrapper = database_wrapper(SqlFamily::Postgres);
+    let wrapper = database_wrapper(SqlFamily::Postgres, &postgres_url());
     let database = Arc::clone(&wrapper.database);
 
     let drop_schema = dbg!(format!("DROP SCHEMA IF EXISTS \"{}\" CASCADE;", SCHEMA_NAME));

--- a/migration-engine/core/tests/existing_databases_tests.rs
+++ b/migration-engine/core/tests/existing_databases_tests.rs
@@ -12,7 +12,7 @@ use test_harness::*;
 
 #[test]
 fn adding_a_model_for_an_existing_table_must_work() {
-    test_each_backend(|api, barrel| {
+    test_each_backend(|test_setup, api, barrel| {
         let initial_result = barrel.execute(|migration| {
             migration.create_table("Blog", |t| {
                 t.add_column("id", types::primary());
@@ -23,7 +23,7 @@ fn adding_a_model_for_an_existing_table_must_work() {
                 id Int @id
             }
         "#;
-        let result = infer_and_apply(api, &dm).sql_schema;
+        let result = infer_and_apply(test_setup, api, &dm).sql_schema;
         assert_eq!(initial_result, result);
     });
 }
@@ -35,7 +35,7 @@ fn bigint_columns_must_work() {
 
 #[test]
 fn removing_a_model_for_a_table_that_is_already_deleted_must_work() {
-    test_each_backend(|api, barrel| {
+    test_each_backend(|test_setup, api, barrel| {
         let dm1 = r#"
             model Blog {
                 id Int @id
@@ -45,7 +45,7 @@ fn removing_a_model_for_a_table_that_is_already_deleted_must_work() {
                 id Int @id
             }
         "#;
-        let initial_result = infer_and_apply(api, &dm1).sql_schema;
+        let initial_result = infer_and_apply(test_setup, api, &dm1).sql_schema;
         assert!(initial_result.has_table("Post"));
 
         let result = barrel.execute(|migration| {
@@ -58,14 +58,14 @@ fn removing_a_model_for_a_table_that_is_already_deleted_must_work() {
                 id Int @id
             }
         "#;
-        let final_result = infer_and_apply(api, &dm2).sql_schema;
+        let final_result = infer_and_apply(test_setup, api, &dm2).sql_schema;
         assert_eq!(result, final_result);
     });
 }
 
 #[test]
 fn creating_a_field_for_an_existing_column_with_a_compatible_type_must_work() {
-    test_each_backend(|api, barrel| {
+    test_each_backend(|test_setup, api, barrel| {
         let initial_result = barrel.execute(|migration| {
             migration.create_table("Blog", |t| {
                 t.add_column("id", types::primary());
@@ -78,14 +78,14 @@ fn creating_a_field_for_an_existing_column_with_a_compatible_type_must_work() {
                 title String
             }
         "#;
-        let result = infer_and_apply(api, &dm).sql_schema;
+        let result = infer_and_apply(test_setup, api, &dm).sql_schema;
         assert_eq!(initial_result, result);
     });
 }
 
 #[test]
 fn creating_a_field_for_an_existing_column_and_changing_its_type_must_work() {
-    test_each_backend(|api, barrel| {
+    test_each_backend(|test_setup, api, barrel| {
         let initial_result = barrel.execute(|migration| {
             migration.create_table("Blog", |t| {
                 t.add_column("id", types::primary());
@@ -102,7 +102,7 @@ fn creating_a_field_for_an_existing_column_and_changing_its_type_must_work() {
                 title String @unique
             }
         "#;
-        let result = infer_and_apply(api, &dm).sql_schema;
+        let result = infer_and_apply(test_setup, api, &dm).sql_schema;
         let table = result.table_bang("Blog");
         let column = table.column_bang("title");
         assert_eq!(column.tpe.family, ColumnTypeFamily::String);
@@ -115,7 +115,7 @@ fn creating_a_field_for_an_existing_column_and_changing_its_type_must_work() {
 
 #[test]
 fn creating_a_field_for_an_existing_column_and_simultaneously_making_it_optional() {
-    test_each_backend(|api, barrel| {
+    test_each_backend(|test_setup, api, barrel| {
         let initial_result = barrel.execute(|migration| {
             migration.create_table("Blog", |t| {
                 t.add_column("id", types::primary());
@@ -131,7 +131,7 @@ fn creating_a_field_for_an_existing_column_and_simultaneously_making_it_optional
                 title String?
             }
         "#;
-        let result = infer_and_apply(api, &dm).sql_schema;
+        let result = infer_and_apply(test_setup, api, &dm).sql_schema;
         let column = result.table_bang("Blog").column_bang("title");
         assert_eq!(column.is_required(), false);
     });
@@ -139,13 +139,13 @@ fn creating_a_field_for_an_existing_column_and_simultaneously_making_it_optional
 
 #[test]
 fn creating_a_scalar_list_field_for_an_existing_table_must_work() {
-    test_each_backend(|api, barrel| {
+    test_each_backend(|test_setup, api, barrel| {
         let dm1 = r#"
             model Blog {
                 id Int @id
             }
         "#;
-        let initial_result = infer_and_apply(api, &dm1).sql_schema;
+        let initial_result = infer_and_apply(test_setup, api, &dm1).sql_schema;
         assert!(!initial_result.has_table("Blog_tags"));
 
         let mut result = barrel.execute(|migration| {
@@ -180,7 +180,7 @@ fn creating_a_scalar_list_field_for_an_existing_table_must_work() {
                 tags String[]
             }
         "#;
-        let mut final_result = infer_and_apply(api, &dm2).sql_schema;
+        let mut final_result = infer_and_apply(test_setup, api, &dm2).sql_schema;
         for table in &mut final_result.tables {
             if table.name == "Blog_tags" {
                 // can't set that properly up again
@@ -194,14 +194,14 @@ fn creating_a_scalar_list_field_for_an_existing_table_must_work() {
 
 #[test]
 fn delete_a_field_for_a_non_existent_column_must_work() {
-    test_each_backend(|api, barrel| {
+    test_each_backend(|test_setup, api, barrel| {
         let dm1 = r#"
             model Blog {
                 id Int @id
                 title String
             }
         "#;
-        let initial_result = infer_and_apply(api, &dm1).sql_schema;
+        let initial_result = infer_and_apply(test_setup, api, &dm1).sql_schema;
         assert_eq!(initial_result.table_bang("Blog").column("title").is_some(), true);
 
         let result = barrel.execute(|migration| {
@@ -218,21 +218,21 @@ fn delete_a_field_for_a_non_existent_column_must_work() {
                 id Int @id
             }
         "#;
-        let final_result = infer_and_apply(api, &dm2).sql_schema;
+        let final_result = infer_and_apply(test_setup, api, &dm2).sql_schema;
         assert_eq!(result, final_result);
     });
 }
 
 #[test]
 fn deleting_a_scalar_list_field_for_a_non_existent_list_table_must_work() {
-    test_each_backend(|api, barrel| {
+    test_each_backend(|test_setup, api, barrel| {
         let dm1 = r#"
             model Blog {
                 id Int @id
                 tags String[]
             }
         "#;
-        let initial_result = infer_and_apply(api, &dm1).sql_schema;
+        let initial_result = infer_and_apply(test_setup, api, &dm1).sql_schema;
         assert!(initial_result.has_table("Blog_tags"));
 
         let result = barrel.execute(|migration| {
@@ -245,21 +245,21 @@ fn deleting_a_scalar_list_field_for_a_non_existent_list_table_must_work() {
                 id Int @id
             }
         "#;
-        let final_result = infer_and_apply(api, &dm2).sql_schema;
+        let final_result = infer_and_apply(test_setup, api, &dm2).sql_schema;
         assert_eq!(result, final_result);
     });
 }
 
 #[test]
 fn updating_a_field_for_a_non_existent_column() {
-    test_each_backend(|api, barrel| {
+    test_each_backend(|test_setup, api, barrel| {
         let dm1 = r#"
             model Blog {
                 id Int @id
                 title String
             }
         "#;
-        let initial_result = infer_and_apply(api, &dm1).sql_schema;
+        let initial_result = infer_and_apply(test_setup, api, &dm1).sql_schema;
         let initial_column = initial_result.table_bang("Blog").column_bang("title");
         assert_eq!(initial_column.tpe.family, ColumnTypeFamily::String);
 
@@ -278,7 +278,7 @@ fn updating_a_field_for_a_non_existent_column() {
                 title Int @unique
             }
         "#;
-        let final_result = infer_and_apply(api, &dm2).sql_schema;
+        let final_result = infer_and_apply(test_setup, api, &dm2).sql_schema;
         let final_column = final_result.table_bang("Blog").column_bang("title");
         assert_eq!(final_column.tpe.family, ColumnTypeFamily::Int);
         let index = final_result
@@ -293,14 +293,14 @@ fn updating_a_field_for_a_non_existent_column() {
 
 #[test]
 fn renaming_a_field_where_the_column_was_already_renamed_must_work() {
-    test_each_backend(|api, barrel| {
+    test_each_backend(|test_setup, api, barrel| {
         let dm1 = r#"
             model Blog {
                 id Int @id
                 title String
             }
         "#;
-        let initial_result = infer_and_apply(api, &dm1).sql_schema;
+        let initial_result = infer_and_apply(test_setup, api, &dm1).sql_schema;
         let initial_column = initial_result.table_bang("Blog").column_bang("title");
         assert_eq!(initial_column.tpe.family, ColumnTypeFamily::String);
 
@@ -321,7 +321,7 @@ fn renaming_a_field_where_the_column_was_already_renamed_must_work() {
             }
         "#;
 
-        let final_result = infer_and_apply(api, &dm2).sql_schema;
+        let final_result = infer_and_apply(test_setup, api, &dm2).sql_schema;
         let final_column = final_result.table_bang("Blog").column_bang("new_title");
 
         assert_eq!(final_column.tpe.family, ColumnTypeFamily::Float);
@@ -331,19 +331,19 @@ fn renaming_a_field_where_the_column_was_already_renamed_must_work() {
 
 fn test_each_backend<F>(test_fn: F)
 where
-    F: Fn(&dyn GenericApi, &BarrelMigrationExecutor) -> () + std::panic::RefUnwindSafe,
+    F: Fn(&TestSetup, &dyn GenericApi, &BarrelMigrationExecutor) -> () + std::panic::RefUnwindSafe,
 {
     test_each_backend_with_ignores(Vec::new(), test_fn);
 }
 
 fn test_each_backend_with_ignores<F>(ignores: Vec<SqlFamily>, test_fn: F)
 where
-    F: Fn(&dyn GenericApi, &BarrelMigrationExecutor) -> () + std::panic::RefUnwindSafe,
+    F: Fn(&TestSetup, &dyn GenericApi, &BarrelMigrationExecutor) -> () + std::panic::RefUnwindSafe,
 {
     // SQLite
     if !ignores.contains(&SqlFamily::Sqlite) {
         println!("Testing with SQLite now");
-        let (inspector, database) = get_sqlite();
+        let (inspector, test_setup) = get_sqlite();
 
         println!("Running the test function now");
         let connector = SqlMigrationConnector::sqlite(&sqlite_test_file()).unwrap();
@@ -351,18 +351,18 @@ where
 
         let barrel_migration_executor = BarrelMigrationExecutor {
             inspector,
-            database,
+            database: Arc::clone(&test_setup.database),
             sql_variant: SqlVariant::Sqlite,
         };
 
-        test_fn(&api, &barrel_migration_executor);
+        test_fn(&test_setup, &api, &barrel_migration_executor);
     } else {
         println!("Ignoring SQLite")
     }
     // POSTGRES
     if !ignores.contains(&SqlFamily::Postgres) {
         println!("Testing with Postgres now");
-        let (inspector, database) = get_postgres();
+        let (inspector, test_setup) = get_postgres();
 
         println!("Running the test function now");
         let connector = SqlMigrationConnector::postgres(&postgres_url(), false).unwrap();
@@ -370,17 +370,17 @@ where
 
         let barrel_migration_executor = BarrelMigrationExecutor {
             inspector,
-            database,
+            database: Arc::clone(&test_setup.database),
             sql_variant: SqlVariant::Pg,
         };
 
-        test_fn(&api, &barrel_migration_executor);
+        test_fn(&test_setup, &api, &barrel_migration_executor);
     } else {
         println!("Ignoring Postgres")
     }
 }
 
-fn get_sqlite() -> (Arc<dyn SqlSchemaDescriberBackend>, Arc<dyn MigrationDatabase>) {
+fn get_sqlite() -> (Arc<dyn SqlSchemaDescriberBackend>, TestSetup) {
     let wrapper = database_wrapper(SqlFamily::Sqlite, &sqlite_test_file());
     let database = Arc::clone(&wrapper.database);
 
@@ -389,10 +389,16 @@ fn get_sqlite() -> (Arc<dyn SqlSchemaDescriberBackend>, Arc<dyn MigrationDatabas
 
     let inspector = sql_schema_describer::sqlite::SqlSchemaDescriber::new(Arc::new(wrapper));
 
-    (Arc::new(inspector), database)
+    (
+        Arc::new(inspector),
+        TestSetup {
+            database,
+            sql_family: SqlFamily::Sqlite,
+        },
+    )
 }
 
-fn get_postgres() -> (Arc<dyn SqlSchemaDescriberBackend>, Arc<dyn MigrationDatabase>) {
+fn get_postgres() -> (Arc<dyn SqlSchemaDescriberBackend>, TestSetup) {
     let wrapper = database_wrapper(SqlFamily::Postgres, &postgres_url());
     let database = Arc::clone(&wrapper.database);
 
@@ -401,12 +407,18 @@ fn get_postgres() -> (Arc<dyn SqlSchemaDescriberBackend>, Arc<dyn MigrationDatab
 
     let inspector = sql_schema_describer::postgres::SqlSchemaDescriber::new(Arc::new(wrapper));
 
-    (Arc::new(inspector), database)
+    (
+        Arc::new(inspector),
+        TestSetup {
+            database,
+            sql_family: SqlFamily::Postgres,
+        },
+    )
 }
 
 struct BarrelMigrationExecutor {
     inspector: Arc<dyn SqlSchemaDescriberBackend>,
-    database: Arc<dyn MigrationDatabase>,
+    database: Arc<dyn MigrationDatabase + Send + Sync>,
     sql_variant: barrel::backend::SqlVariant,
 }
 
@@ -429,7 +441,7 @@ impl BarrelMigrationExecutor {
     }
 }
 
-fn run_full_sql(database: &Arc<dyn MigrationDatabase>, full_sql: &str) {
+fn run_full_sql(database: &Arc<dyn MigrationDatabase + Send + Sync>, full_sql: &str) {
     for sql in full_sql.split(";") {
         if sql != "" {
             database.query_raw(SCHEMA_NAME, &sql, &[]).unwrap();

--- a/migration-engine/core/tests/infer_migration_steps_tests.rs
+++ b/migration-engine/core/tests/infer_migration_steps_tests.rs
@@ -8,14 +8,14 @@ use test_harness::*;
 
 #[test]
 fn assume_to_be_applied_must_work() {
-    test_each_connector(|_, api| {
+    test_each_connector(|test_setup, api| {
         let dm0 = r#"
             model Blog {
                 id Int @id
             }
         "#;
 
-        infer_and_apply_with_migration_id(api, &dm0, "mig0000");
+        infer_and_apply_with_migration_id(test_setup, api, &dm0, "mig0000");
 
         let dm1 = r#"
             model Blog {
@@ -50,14 +50,14 @@ fn assume_to_be_applied_must_work() {
 
 #[test]
 fn special_handling_of_watch_migrations() {
-    test_each_connector(|_, api| {
+    test_each_connector(|test_setup, api| {
         let dm = r#"
             model Blog {
                 id Int @id
             }
         "#;
 
-        infer_and_apply_with_migration_id(api, &dm, "mig00");
+        infer_and_apply_with_migration_id(test_setup, api, &dm, "mig00");
 
         let dm = r#"
             model Blog {
@@ -66,7 +66,7 @@ fn special_handling_of_watch_migrations() {
             }
         "#;
 
-        infer_and_apply_with_migration_id(api, &dm, "watch01");
+        infer_and_apply_with_migration_id(test_setup, api, &dm, "watch01");
 
         let dm = r#"
             model Blog {
@@ -76,7 +76,7 @@ fn special_handling_of_watch_migrations() {
             }
         "#;
 
-        infer_and_apply_with_migration_id(api, &dm, "watch02");
+        infer_and_apply_with_migration_id(test_setup, api, &dm, "watch02");
 
         let dm = r#"
             model Blog {

--- a/migration-engine/core/tests/migration_persistence_tests.rs
+++ b/migration-engine/core/tests/migration_persistence_tests.rs
@@ -37,14 +37,14 @@ fn load_all_should_return_empty_if_there_is_no_migration() {
 
 #[test]
 fn load_all_must_return_all_created_migrations() {
-    test_each_connector(|sql_family, api| {
+    test_each_connector(|test_setup, api| {
         let persistence = api.migration_persistence();
         let migration1 = persistence.create(Migration::new("migration_1".to_string()));
         let migration2 = persistence.create(Migration::new("migration_2".to_string()));
         let migration3 = persistence.create(Migration::new("migration_3".to_string()));
 
         let mut result = persistence.load_all();
-        if sql_family == SqlFamily::Mysql {
+        if test_setup.sql_family == SqlFamily::Mysql {
             // TODO: mysql currently looses milli seconds on loading
             result[0].started_at = migration1.started_at;
             result[1].started_at = migration2.started_at;
@@ -56,13 +56,13 @@ fn load_all_must_return_all_created_migrations() {
 
 #[test]
 fn create_should_allow_to_create_a_new_migration() {
-    test_each_connector(|sql_family, api| {
+    test_each_connector(|test_setup, api| {
         let datamodel = datamodel::parse_datamodel(
             r#"
-            model Test {
-                id String @id @default(cuid())
-            }
-        "#,
+                model Test {
+                    id String @id @default(cuid())
+                }
+            "#,
         )
         .unwrap();
         let persistence = api.migration_persistence();
@@ -81,7 +81,7 @@ fn create_should_allow_to_create_a_new_migration() {
 
         assert_eq!(result, migration);
         let mut loaded = persistence.last().unwrap();
-        if sql_family == SqlFamily::Mysql {
+        if test_setup.sql_family == SqlFamily::Mysql {
             // TODO: mysql currently looses milli seconds on loading
             loaded.started_at = migration.started_at;
         }
@@ -101,7 +101,7 @@ fn create_should_increment_revisions() {
 
 #[test]
 fn update_must_work() {
-    test_each_connector(|sql_family, api| {
+    test_each_connector(|test_setup, api| {
         let persistence = api.migration_persistence();
         let migration = persistence.create(Migration::new("my_migration".to_string()));
 
@@ -120,7 +120,7 @@ fn update_must_work() {
         assert_eq!(loaded.applied, params.applied);
         assert_eq!(loaded.rolled_back, params.rolled_back);
         assert_eq!(loaded.errors, params.errors);
-        if sql_family != SqlFamily::Mysql {
+        if test_setup.sql_family != SqlFamily::Mysql {
             // TODO: mysql currently looses milli seconds on loading
             assert_eq!(loaded.finished_at, params.finished_at);
         }

--- a/migration-engine/core/tests/migration_tests.rs
+++ b/migration-engine/core/tests/migration_tests.rs
@@ -232,7 +232,7 @@ fn changing_the_type_of_an_id_field_must_work() {
         assert_eq!(
             table.foreign_keys,
             &[ForeignKey {
-                constraint_name: match sql_family {
+                constraint_name: match test_setup.sql_family {
                     SqlFamily::Postgres => Some("A_b_fkey".to_owned()),
                     SqlFamily::Mysql => Some("A_ibfk_1".to_owned()),
                     SqlFamily::Sqlite => None,
@@ -260,7 +260,7 @@ fn changing_the_type_of_an_id_field_must_work() {
         assert_eq!(
             table.foreign_keys,
             &[ForeignKey {
-                constraint_name: match sql_family {
+                constraint_name: match test_setup.sql_family {
                     SqlFamily::Postgres => Some("A_b_fkey".to_owned()),
                     SqlFamily::Mysql => Some("A_ibfk_1".to_owned()),
                     SqlFamily::Sqlite => None,
@@ -301,7 +301,7 @@ fn updating_db_name_of_a_scalar_field_must_work() {
 #[test]
 fn changing_a_relation_field_to_a_scalar_field_must_work() {
     // this relies on link: INLINE which we don't support yet
-    test_each_connector_with_ignores(&[SqlFamily::Mysql], |sql_family, api| {
+    test_each_connector_with_ignores(&[SqlFamily::Mysql], |test_setup, api| {
         let dm1 = r#"
             model A {
                 id Int @id
@@ -319,7 +319,7 @@ fn changing_a_relation_field_to_a_scalar_field_must_work() {
         assert_eq!(
             table.foreign_keys,
             &[ForeignKey {
-                constraint_name: match sql_family {
+                constraint_name: match test_setup.sql_family {
                     SqlFamily::Postgres => Some("A_b_fkey".to_owned()),
                     SqlFamily::Mysql => Some("A_ibfk_1".to_owned()),
                     SqlFamily::Sqlite => None,
@@ -383,7 +383,7 @@ fn changing_a_scalar_field_to_a_relation_field_must_work() {
         assert_eq!(
             table.foreign_keys,
             &[ForeignKey {
-                constraint_name: match sql_family {
+                constraint_name: match test_setup.sql_family {
                     SqlFamily::Postgres => Some("A_b_fkey".to_owned()),
                     SqlFamily::Mysql => Some("A_ibfk_1".to_owned()),
                     SqlFamily::Sqlite => None,
@@ -425,7 +425,7 @@ fn adding_a_many_to_many_relation_must_result_in_a_prisma_style_relation_table()
             relation_table.foreign_keys,
             &[
                 ForeignKey {
-                    constraint_name: match sql_family {
+                    constraint_name: match test_setup.sql_family {
                         SqlFamily::Postgres => Some("_AToB_A_fkey".to_owned()),
                         SqlFamily::Mysql => Some("_AToB_ibfk_1".to_owned()),
                         SqlFamily::Sqlite => None,
@@ -436,7 +436,7 @@ fn adding_a_many_to_many_relation_must_result_in_a_prisma_style_relation_table()
                     on_delete_action: ForeignKeyAction::Cascade,
                 },
                 ForeignKey {
-                    constraint_name: match sql_family {
+                    constraint_name: match test_setup.sql_family {
                         SqlFamily::Postgres => Some("_AToB_B_fkey".to_owned()),
                         SqlFamily::Mysql => Some("_AToB_ibfk_2".to_owned()),
                         SqlFamily::Sqlite => None,
@@ -478,7 +478,7 @@ fn adding_a_many_to_many_relation_with_custom_name_must_work() {
             relation_table.foreign_keys,
             vec![
                 ForeignKey {
-                    constraint_name: match sql_family {
+                    constraint_name: match test_setup.sql_family {
                         SqlFamily::Postgres => Some("_my_relation_A_fkey".to_owned()),
                         SqlFamily::Mysql => Some("_my_relation_ibfk_1".to_owned()),
                         SqlFamily::Sqlite => None,
@@ -489,7 +489,7 @@ fn adding_a_many_to_many_relation_with_custom_name_must_work() {
                     on_delete_action: ForeignKeyAction::Cascade,
                 },
                 ForeignKey {
-                    constraint_name: match sql_family {
+                    constraint_name: match test_setup.sql_family {
                         SqlFamily::Postgres => Some("_my_relation_B_fkey".to_owned()),
                         SqlFamily::Mysql => Some("_my_relation_ibfk_2".to_owned()),
                         SqlFamily::Sqlite => None,
@@ -552,7 +552,7 @@ fn adding_an_inline_relation_must_result_in_a_foreign_key_in_the_model_table() {
         assert_eq!(
             table.foreign_keys,
             &[ForeignKey {
-                constraint_name: match sql_family {
+                constraint_name: match test_setup.sql_family {
                     SqlFamily::Postgres => Some("A_b_fkey".to_owned()),
                     SqlFamily::Mysql => Some("A_ibfk_1".to_owned()),
                     SqlFamily::Sqlite => None,
@@ -586,7 +586,7 @@ fn specifying_a_db_name_for_an_inline_relation_must_work() {
         assert_eq!(
             table.foreign_keys,
             &[ForeignKey {
-                constraint_name: match sql_family {
+                constraint_name: match test_setup.sql_family {
                     SqlFamily::Postgres => Some("A_b_column_fkey".to_owned()),
                     SqlFamily::Mysql => Some("A_ibfk_1".to_owned()),
                     SqlFamily::Sqlite => None,
@@ -620,7 +620,7 @@ fn adding_an_inline_relation_to_a_model_with_an_exotic_id_type() {
         assert_eq!(
             table.foreign_keys,
             &[ForeignKey {
-                constraint_name: match sql_family {
+                constraint_name: match test_setup.sql_family {
                     SqlFamily::Postgres => Some("A_b_fkey".to_owned()),
                     SqlFamily::Mysql => Some("A_ibfk_1".to_owned()),
                     SqlFamily::Sqlite => None,
@@ -684,7 +684,7 @@ fn moving_an_inline_relation_to_the_other_side_must_work() {
         assert_eq!(
             table.foreign_keys,
             &[ForeignKey {
-                constraint_name: match sql_family {
+                constraint_name: match test_setup.sql_family {
                     SqlFamily::Postgres => Some("A_b_fkey".to_owned()),
                     SqlFamily::Sqlite => None,
                     SqlFamily::Mysql => unreachable!(),
@@ -711,7 +711,7 @@ fn moving_an_inline_relation_to_the_other_side_must_work() {
         assert_eq!(
             table.foreign_keys,
             &[ForeignKey {
-                constraint_name: match sql_family {
+                constraint_name: match test_setup.sql_family {
                     SqlFamily::Postgres => Some("B_a_fkey".to_owned()),
                     SqlFamily::Sqlite => None,
                     SqlFamily::Mysql => unreachable!(),
@@ -1329,6 +1329,7 @@ fn updating_a_model_with_a_scalar_list_to_a_different_id_type_must_work() {
 fn reserved_sql_key_words_must_work() {
     // Group is a reserved keyword
     test_each_connector(|test_setup, api| {
+        let sql_family = test_setup.sql_family;
         let dm = r#"
             model Group {
                 id    String  @default(cuid()) @id
@@ -1420,7 +1421,9 @@ fn migrations_with_many_to_many_related_models_must_not_recreate_indexes() {
 
 #[test]
 fn removing_a_relation_field_must_work() {
-    test_each_connector(|sql_family, api| {
+    test_each_connector(|test_setup, api| {
+        let sql_family = test_setup.sql_family;
+
         let dm_1 = r#"
             model User {
                 id        String  @default(cuid()) @id
@@ -1433,7 +1436,7 @@ fn removing_a_relation_field_must_work() {
             }
         "#;
 
-        let sql_schema = infer_and_apply(api, &dm_1).sql_schema;
+        let sql_schema = infer_and_apply(test_setup, api, &dm_1).sql_schema;
 
         let address_name_field = sql_schema
             .table_bang("User")
@@ -1454,7 +1457,7 @@ fn removing_a_relation_field_must_work() {
             }
         "#;
 
-        let sql_schema = infer_and_apply(api, &dm_2).sql_schema;
+        let sql_schema = infer_and_apply(test_setup, api, &dm_2).sql_schema;
 
         let address_name_field = sql_schema
             .table_bang("User")

--- a/migration-engine/core/tests/migration_tests.rs
+++ b/migration-engine/core/tests/migration_tests.rs
@@ -93,7 +93,7 @@ fn adding_an_id_field_with_a_special_name_must_work() {
 
 #[test]
 fn adding_an_id_field_of_type_int_must_work() {
-    test_each_connector(|sql_family, api| {
+    test_each_connector(|test_setup, api| {
         let dm2 = r#"
             model Test {
                 myId Int @id
@@ -101,7 +101,7 @@ fn adding_an_id_field_of_type_int_must_work() {
         "#;
         let result = infer_and_apply(api, &dm2).sql_schema;
         let column = result.table_bang("Test").column_bang("myId");
-        match sql_family {
+        match test_setup.sql_family {
             SqlFamily::Postgres => {
                 let sequence = result.get_sequence("Test_myId_seq").expect("sequence must exist");
                 let default = column.default.as_ref().expect("Must have nextval default");

--- a/migration-engine/core/tests/migration_tests.rs
+++ b/migration-engine/core/tests/migration_tests.rs
@@ -8,7 +8,7 @@ use test_harness::*;
 
 #[test]
 fn adding_a_scalar_field_must_work() {
-    test_each_connector(|_, api| {
+    test_each_connector(|test_setup, api| {
         let dm2 = r#"
             model Test {
                 id String @id @default(cuid())
@@ -25,7 +25,7 @@ fn adding_a_scalar_field_must_work() {
                 B
             }
         "#;
-        let result = infer_and_apply(api, &dm2).sql_schema;
+        let result = infer_and_apply(test_setup, api, &dm2).sql_schema;
         let table = result.table_bang("Test");
         table.columns.iter().for_each(|c| assert_eq!(c.is_required(), true));
 
@@ -58,20 +58,20 @@ fn adding_a_scalar_field_must_work() {
 //            }
 //        "#;
 //
-//        infer_and_apply(api, &dm2);
+//        infer_and_apply(test_setup, api, &dm2);
 //    });
 //}
 
 #[test]
 fn adding_an_optional_field_must_work() {
-    test_each_connector(|_, api| {
+    test_each_connector(|test_setup, api| {
         let dm2 = r#"
             model Test {
                 id String @id @default(cuid())
                 field String?
             }
         "#;
-        let result = infer_and_apply(api, &dm2).sql_schema;
+        let result = infer_and_apply(test_setup, api, &dm2).sql_schema;
         let column = result.table_bang("Test").column_bang("field");
         assert_eq!(column.is_required(), false);
     });
@@ -79,13 +79,13 @@ fn adding_an_optional_field_must_work() {
 
 #[test]
 fn adding_an_id_field_with_a_special_name_must_work() {
-    test_each_connector(|_, api| {
+    test_each_connector(|test_setup, api| {
         let dm2 = r#"
             model Test {
                 specialName String @id @default(cuid())
             }
         "#;
-        let result = infer_and_apply(api, &dm2).sql_schema;
+        let result = infer_and_apply(test_setup, api, &dm2).sql_schema;
         let column = result.table_bang("Test").column("specialName");
         assert_eq!(column.is_some(), true);
     });
@@ -99,7 +99,8 @@ fn adding_an_id_field_of_type_int_must_work() {
                 myId Int @id
             }
         "#;
-        let result = infer_and_apply(api, &dm2).sql_schema;
+
+        let result = infer_and_apply(test_setup, api, &dm2).sql_schema;
         let column = result.table_bang("Test").column_bang("myId");
         match test_setup.sql_family {
             SqlFamily::Postgres => {
@@ -115,14 +116,14 @@ fn adding_an_id_field_of_type_int_must_work() {
 
 #[test]
 fn removing_a_scalar_field_must_work() {
-    test_each_connector(|_, api| {
+    test_each_connector(|test_setup, api| {
         let dm1 = r#"
             model Test {
                 id String @id @default(cuid())
                 field String
             }
         "#;
-        let result = infer_and_apply(api, &dm1).sql_schema;
+        let result = infer_and_apply(test_setup, api, &dm1).sql_schema;
         let column1 = result.table_bang("Test").column("field");
         assert_eq!(column1.is_some(), true);
 
@@ -131,7 +132,7 @@ fn removing_a_scalar_field_must_work() {
                 id String @id @default(cuid())
             }
         "#;
-        let result = infer_and_apply(api, &dm2).sql_schema;
+        let result = infer_and_apply(test_setup, api, &dm2).sql_schema;
         let column2 = result.table_bang("Test").column("field");
         assert_eq!(column2.is_some(), false);
     });
@@ -139,14 +140,14 @@ fn removing_a_scalar_field_must_work() {
 
 #[test]
 fn can_handle_reserved_sql_keywords_for_model_name() {
-    test_each_connector(|_, api| {
+    test_each_connector(|test_setup, api| {
         let dm1 = r#"
             model Group {
                 id String @id @default(cuid())
                 field String
             }
         "#;
-        let result = infer_and_apply(api, &dm1).sql_schema;
+        let result = infer_and_apply(test_setup, api, &dm1).sql_schema;
         let column = result.table_bang("Group").column_bang("field");
         assert_eq!(column.tpe.family, ColumnTypeFamily::String);
 
@@ -156,7 +157,7 @@ fn can_handle_reserved_sql_keywords_for_model_name() {
                 field Int
             }
         "#;
-        let result = infer_and_apply(api, &dm2).sql_schema;
+        let result = infer_and_apply(test_setup, api, &dm2).sql_schema;
         let column = result.table_bang("Group").column_bang("field");
         assert_eq!(column.tpe.family, ColumnTypeFamily::Int);
     });
@@ -164,14 +165,14 @@ fn can_handle_reserved_sql_keywords_for_model_name() {
 
 #[test]
 fn can_handle_reserved_sql_keywords_for_field_name() {
-    test_each_connector(|_, api| {
+    test_each_connector(|test_setup, api| {
         let dm1 = r#"
             model Test {
                 id String @id @default(cuid())
                 Group String
             }
         "#;
-        let result = infer_and_apply(api, &dm1).sql_schema;
+        let result = infer_and_apply(test_setup, api, &dm1).sql_schema;
         let column = result.table_bang("Test").column_bang("Group");
         assert_eq!(column.tpe.family, ColumnTypeFamily::String);
 
@@ -181,7 +182,7 @@ fn can_handle_reserved_sql_keywords_for_field_name() {
                 Group Int
             }
         "#;
-        let result = infer_and_apply(api, &dm2).sql_schema;
+        let result = infer_and_apply(test_setup, api, &dm2).sql_schema;
         let column = result.table_bang("Test").column_bang("Group");
         assert_eq!(column.tpe.family, ColumnTypeFamily::Int);
     });
@@ -189,14 +190,14 @@ fn can_handle_reserved_sql_keywords_for_field_name() {
 
 #[test]
 fn update_type_of_scalar_field_must_work() {
-    test_each_connector(|_, api| {
+    test_each_connector(|test_setup, api| {
         let dm1 = r#"
             model Test {
                 id String @id @default(cuid())
                 field String
             }
         "#;
-        let result = infer_and_apply(api, &dm1).sql_schema;
+        let result = infer_and_apply(test_setup, api, &dm1).sql_schema;
         let column1 = result.table_bang("Test").column_bang("field");
         assert_eq!(column1.tpe.family, ColumnTypeFamily::String);
 
@@ -206,7 +207,7 @@ fn update_type_of_scalar_field_must_work() {
                 field Int
             }
         "#;
-        let result = infer_and_apply(api, &dm2).sql_schema;
+        let result = infer_and_apply(test_setup, api, &dm2).sql_schema;
         let column2 = result.table_bang("Test").column_bang("field");
         assert_eq!(column2.tpe.family, ColumnTypeFamily::Int);
     });
@@ -214,7 +215,7 @@ fn update_type_of_scalar_field_must_work() {
 
 #[test]
 fn changing_the_type_of_an_id_field_must_work() {
-    test_each_connector(|sql_family, api| {
+    test_each_connector(|test_setup, api| {
         let dm1 = r#"
             model A {
                 id Int @id
@@ -224,7 +225,7 @@ fn changing_the_type_of_an_id_field_must_work() {
                 id Int @id
             }
         "#;
-        let result = infer_and_apply(api, &dm1).sql_schema;
+        let result = infer_and_apply(test_setup, api, &dm1).sql_schema;
         let table = result.table_bang("A");
         let column = table.column_bang("b");
         assert_eq!(column.tpe.family, ColumnTypeFamily::Int);
@@ -252,7 +253,7 @@ fn changing_the_type_of_an_id_field_must_work() {
                 id String @id @default(cuid())
             }
         "#;
-        let result = infer_and_apply(api, &dm2).sql_schema;
+        let result = infer_and_apply(test_setup, api, &dm2).sql_schema;
         let table = result.table_bang("A");
         let column = table.column_bang("b");
         assert_eq!(column.tpe.family, ColumnTypeFamily::String);
@@ -275,14 +276,14 @@ fn changing_the_type_of_an_id_field_must_work() {
 
 #[test]
 fn updating_db_name_of_a_scalar_field_must_work() {
-    test_each_connector(|_, api| {
+    test_each_connector(|test_setup, api| {
         let dm1 = r#"
             model A {
                 id String @id @default(cuid())
                 field String @map(name:"name1")
             }
         "#;
-        let result = infer_and_apply(api, &dm1).sql_schema;
+        let result = infer_and_apply(test_setup, api, &dm1).sql_schema;
         assert_eq!(result.table_bang("A").column("name1").is_some(), true);
 
         let dm2 = r#"
@@ -291,7 +292,7 @@ fn updating_db_name_of_a_scalar_field_must_work() {
                 field String @map(name:"name2")
             }
         "#;
-        let result = infer_and_apply(api, &dm2).sql_schema;
+        let result = infer_and_apply(test_setup, api, &dm2).sql_schema;
         assert_eq!(result.table_bang("A").column("name1").is_some(), false);
         assert_eq!(result.table_bang("A").column("name2").is_some(), true);
     });
@@ -311,7 +312,7 @@ fn changing_a_relation_field_to_a_scalar_field_must_work() {
                 a A // remove this once the implicit back relation field is implemented
             }
         "#;
-        let result = infer_and_apply(api, &dm1).sql_schema;
+        let result = infer_and_apply(test_setup, api, &dm1).sql_schema;
         let table = result.table_bang("A");
         let column = table.column_bang("b");
         assert_eq!(column.tpe.family, ColumnTypeFamily::Int);
@@ -339,7 +340,7 @@ fn changing_a_relation_field_to_a_scalar_field_must_work() {
                 id Int @id
             }
         "#;
-        let result = infer_and_apply(api, &dm2).sql_schema;
+        let result = infer_and_apply(test_setup, api, &dm2).sql_schema;
         let table = result.table_bang("A");
         let column = table.column_bang("b");
         assert_eq!(column.tpe.family, ColumnTypeFamily::String);
@@ -349,7 +350,7 @@ fn changing_a_relation_field_to_a_scalar_field_must_work() {
 
 #[test]
 fn changing_a_scalar_field_to_a_relation_field_must_work() {
-    test_each_connector(|sql_family, api| {
+    test_each_connector(|test_setup, api| {
         let dm1 = r#"
             model A {
                 id Int @id
@@ -359,7 +360,7 @@ fn changing_a_scalar_field_to_a_relation_field_must_work() {
                 id Int @id
             }
         "#;
-        let result = infer_and_apply(api, &dm1).sql_schema;
+        let result = infer_and_apply(test_setup, api, &dm1).sql_schema;
         let table = result.table_bang("A");
         let column = table.column_bang("b");
         assert_eq!(column.tpe.family, ColumnTypeFamily::String);
@@ -375,7 +376,7 @@ fn changing_a_scalar_field_to_a_relation_field_must_work() {
                 a A // remove this once the implicit back relation field is implemented
             }
         "#;
-        let result = infer_and_apply(api, &dm2).sql_schema;
+        let result = infer_and_apply(test_setup, api, &dm2).sql_schema;
         let table = result.table_bang("A");
         let column = result.table_bang("A").column_bang("b");
         assert_eq!(column.tpe.family, ColumnTypeFamily::Int);
@@ -399,7 +400,7 @@ fn changing_a_scalar_field_to_a_relation_field_must_work() {
 #[test]
 fn adding_a_many_to_many_relation_must_result_in_a_prisma_style_relation_table() {
     // TODO: one model should have an id of different type. Not possible right now due to barrel limitation.
-    test_each_connector(|sql_family, api| {
+    test_each_connector(|test_setup, api| {
         let dm1 = r#"
             model A {
                 id Int @id
@@ -410,7 +411,7 @@ fn adding_a_many_to_many_relation_must_result_in_a_prisma_style_relation_table()
                 as A[]
             }
         "#;
-        let result = infer_and_apply(api, &dm1).sql_schema;
+        let result = infer_and_apply(test_setup, api, &dm1).sql_schema;
         let relation_table = result.table_bang("_AToB");
         println!("{:?}", relation_table.foreign_keys);
         assert_eq!(relation_table.columns.len(), 2);
@@ -452,7 +453,7 @@ fn adding_a_many_to_many_relation_must_result_in_a_prisma_style_relation_table()
 
 #[test]
 fn adding_a_many_to_many_relation_with_custom_name_must_work() {
-    test_each_connector(|sql_family, api| {
+    test_each_connector(|test_setup, api| {
         let dm1 = r#"
             model A {
                 id Int @id
@@ -464,7 +465,7 @@ fn adding_a_many_to_many_relation_with_custom_name_must_work() {
             }
         "#;
 
-        let result = infer_and_apply(api, &dm1).sql_schema;
+        let result = infer_and_apply(test_setup, api, &dm1).sql_schema;
         let relation_table = result.table_bang("_my_relation");
         assert_eq!(relation_table.columns.len(), 2);
 
@@ -533,7 +534,7 @@ fn providing_an_explicit_link_table_must_work() {
 
 #[test]
 fn adding_an_inline_relation_must_result_in_a_foreign_key_in_the_model_table() {
-    test_each_connector(|sql_family, api| {
+    test_each_connector(|test_setup, api| {
         let dm1 = r#"
             model A {
                 id Int @id
@@ -544,7 +545,7 @@ fn adding_an_inline_relation_must_result_in_a_foreign_key_in_the_model_table() {
                 id Int @id
             }
         "#;
-        let result = dbg!(infer_and_apply(api, &dm1).sql_schema);
+        let result = dbg!(infer_and_apply(test_setup, api, &dm1).sql_schema);
         let table = result.table_bang("A");
         let column = table.column_bang("b");
         assert_eq!(column.tpe.family, ColumnTypeFamily::Int);
@@ -567,7 +568,7 @@ fn adding_an_inline_relation_must_result_in_a_foreign_key_in_the_model_table() {
 
 #[test]
 fn specifying_a_db_name_for_an_inline_relation_must_work() {
-    test_each_connector(|sql_family, api| {
+    test_each_connector(|test_setup, api| {
         let dm1 = r#"
             model A {
                 id Int @id
@@ -578,7 +579,7 @@ fn specifying_a_db_name_for_an_inline_relation_must_work() {
                 id Int @id
             }
         "#;
-        let result = infer_and_apply(api, &dm1).sql_schema;
+        let result = infer_and_apply(test_setup, api, &dm1).sql_schema;
         let table = result.table_bang("A");
         let column = table.column_bang("b_column");
         assert_eq!(column.tpe.family, ColumnTypeFamily::Int);
@@ -601,7 +602,7 @@ fn specifying_a_db_name_for_an_inline_relation_must_work() {
 
 #[test]
 fn adding_an_inline_relation_to_a_model_with_an_exotic_id_type() {
-    test_each_connector(|sql_family, api| {
+    test_each_connector(|test_setup, api| {
         let dm1 = r#"
             model A {
                 id Int @id
@@ -612,7 +613,7 @@ fn adding_an_inline_relation_to_a_model_with_an_exotic_id_type() {
                 id String @id @default(cuid())
             }
         "#;
-        let result = dbg!(infer_and_apply(api, &dm1).sql_schema);
+        let result = dbg!(infer_and_apply(test_setup, api, &dm1).sql_schema);
         let table = result.table_bang("A");
         let column = table.column_bang("b");
         assert_eq!(column.tpe.family, ColumnTypeFamily::String);
@@ -635,7 +636,7 @@ fn adding_an_inline_relation_to_a_model_with_an_exotic_id_type() {
 
 #[test]
 fn removing_an_inline_relation_must_work() {
-    test_each_connector_with_ignores(vec![SqlFamily::Mysql], |_, api| {
+    test_each_connector_with_ignores(vec![SqlFamily::Mysql], |test_setup, api| {
         let dm1 = r#"
             model A {
                 id Int @id
@@ -646,7 +647,7 @@ fn removing_an_inline_relation_must_work() {
                 id Int @id
             }
         "#;
-        let result = infer_and_apply(api, &dm1).sql_schema;
+        let result = dbg!(infer_and_apply(test_setup, api, &dm1).sql_schema);
         let column = result.table_bang("A").column("b");
         assert_eq!(column.is_some(), true);
 
@@ -659,7 +660,7 @@ fn removing_an_inline_relation_must_work() {
                 id Int @id
             }
         "#;
-        let result = infer_and_apply(api, &dm2).sql_schema;
+        let result = dbg!(infer_and_apply(test_setup, api, &dm2).sql_schema);
         let column = result.table_bang("A").column("b");
         assert_eq!(column.is_some(), false);
     });
@@ -667,7 +668,7 @@ fn removing_an_inline_relation_must_work() {
 
 #[test]
 fn moving_an_inline_relation_to_the_other_side_must_work() {
-    test_each_connector_with_ignores(vec![SqlFamily::Mysql], |sql_family, api| {
+    test_each_connector_with_ignores(vec![SqlFamily::Mysql], |test_setup, api| {
         let dm1 = r#"
             model A {
                 id Int @id
@@ -678,7 +679,7 @@ fn moving_an_inline_relation_to_the_other_side_must_work() {
                 id Int @id
             }
         "#;
-        let result = infer_and_apply(api, &dm1).sql_schema;
+        let result = infer_and_apply(test_setup, api, &dm1).sql_schema;
         let table = result.table_bang("A");
         assert_eq!(
             table.foreign_keys,
@@ -705,7 +706,7 @@ fn moving_an_inline_relation_to_the_other_side_must_work() {
                 a A @relation(references: [id])
             }
         "#;
-        let result = infer_and_apply(api, &dm2).sql_schema;
+        let result = infer_and_apply(test_setup, api, &dm2).sql_schema;
         let table = result.table_bang("B");
         assert_eq!(
             table.foreign_keys,
@@ -726,14 +727,14 @@ fn moving_an_inline_relation_to_the_other_side_must_work() {
 
 #[test]
 fn adding_a_new_unique_field_must_work() {
-    test_each_connector(|_, api| {
+    test_each_connector(|test_setup, api| {
         let dm1 = r#"
             model A {
                 id Int @id
                 field String @unique
             }
         "#;
-        let result = infer_and_apply(api, &dm1).sql_schema;
+        let result = infer_and_apply(test_setup, api, &dm1).sql_schema;
         let index = result.table_bang("A").indices.iter().find(|i| i.columns == &["field"]);
         assert!(index.is_some());
         assert_eq!(index.unwrap().tpe, IndexType::Unique);
@@ -742,7 +743,7 @@ fn adding_a_new_unique_field_must_work() {
 
 #[test]
 fn adding_new_fields_with_multi_column_unique_must_work() {
-    test_each_connector(|_, api| {
+    test_each_connector(|test_setup, api| {
         let dm1 = r#"
             model A {
                 id Int @id
@@ -752,7 +753,7 @@ fn adding_new_fields_with_multi_column_unique_must_work() {
                 @@unique([field, secondField])
             }
         "#;
-        let result = infer_and_apply(api, &dm1).sql_schema;
+        let result = infer_and_apply(test_setup, api, &dm1).sql_schema;
         let index = result
             .table_bang("A")
             .indices
@@ -765,14 +766,14 @@ fn adding_new_fields_with_multi_column_unique_must_work() {
 
 #[test]
 fn unique_in_conjunction_with_custom_column_name_must_work() {
-    test_each_connector(|_, api| {
+    test_each_connector(|test_setup, api| {
         let dm1 = r#"
             model A {
                 id Int @id
                 field String @unique @map("custom_field_name")
             }
         "#;
-        let result = infer_and_apply(api, &dm1).sql_schema;
+        let result = infer_and_apply(test_setup, api, &dm1).sql_schema;
         let index = result
             .table_bang("A")
             .indices
@@ -810,14 +811,14 @@ fn multi_column_unique_in_conjunction_with_custom_column_name_must_work() {
 fn sqlite_must_recreate_indexes() {
     // SQLite must go through a complicated migration procedure which requires dropping and recreating indexes. This test checks that.
     // We run them still against each connector.
-    test_each_connector(|_, api| {
+    test_each_connector(|test_setup, api| {
         let dm1 = r#"
             model A {
                 id Int @id
                 field String @unique
             }
         "#;
-        let result = infer_and_apply(api, &dm1).sql_schema;
+        let result = infer_and_apply(test_setup, api, &dm1).sql_schema;
         let index = result
             .table_bang("A")
             .indices
@@ -833,7 +834,7 @@ fn sqlite_must_recreate_indexes() {
                 other String
             }
         "#;
-        let result = infer_and_apply(api, &dm2).sql_schema;
+        let result = infer_and_apply(test_setup, api, &dm2).sql_schema;
         let index = result
             .table_bang("A")
             .indices
@@ -890,14 +891,15 @@ fn sqlite_must_recreate_multi_field_indexes() {
 
 #[test]
 fn removing_an_existing_unique_field_must_work() {
-    test_each_connector(|_, api| {
+    //    test_only_connector(SqlFamily::Postgres, |test_setup, api| {
+    test_each_connector(|test_setup, api| {
         let dm1 = r#"
             model A {
                 id    Int    @id
                 field String @unique
             }
         "#;
-        let result = infer_and_apply(api, &dm1).sql_schema;
+        let result = infer_and_apply(test_setup, api, &dm1).sql_schema;
         let index = result
             .table_bang("A")
             .indices
@@ -911,7 +913,7 @@ fn removing_an_existing_unique_field_must_work() {
                 id    Int    @id
             }
         "#;
-        let result = infer_and_apply(api, &dm2).sql_schema;
+        let result = dbg!(infer_and_apply(test_setup, api, &dm2).sql_schema);
         let index = result
             .table_bang("A")
             .indices
@@ -923,14 +925,14 @@ fn removing_an_existing_unique_field_must_work() {
 
 #[test]
 fn adding_unique_to_an_existing_field_must_work() {
-    test_each_connector(|_, api| {
+    test_each_connector(|test_setup, api| {
         let dm1 = r#"
             model A {
                 id    Int    @id
                 field String
             }
         "#;
-        let result = infer_and_apply(api, &dm1).sql_schema;
+        let result = infer_and_apply(test_setup, api, &dm1).sql_schema;
         let index = result
             .table_bang("A")
             .indices
@@ -944,7 +946,7 @@ fn adding_unique_to_an_existing_field_must_work() {
                 field String @unique
             }
         "#;
-        let result = infer_and_apply(api, &dm2).sql_schema;
+        let result = infer_and_apply(test_setup, api, &dm2).sql_schema;
         let index = result
             .table_bang("A")
             .indices
@@ -957,7 +959,8 @@ fn adding_unique_to_an_existing_field_must_work() {
 
 #[test]
 fn removing_unique_from_an_existing_field_must_work() {
-    test_each_connector(|_, api| {
+    //    test_only_connector(SqlFamily::Postgres, |test_setup, api| {
+    test_each_connector(|test_setup, api| {
         let dm1 = r#"
             model A {
                 id    Int    @id
@@ -983,7 +986,7 @@ fn removing_unique_from_an_existing_field_must_work() {
 
 #[test]
 fn removing_multi_field_unique_index_must_work() {
-    test_each_connector(|_, api| {
+    test_each_connector(|test_setup, api| {
         let dm1 = r#"
             model A {
                 id    Int    @id
@@ -993,7 +996,7 @@ fn removing_multi_field_unique_index_must_work() {
                 @@unique([field, secondField])
             }
         "#;
-        let result = infer_and_apply(api, &dm1).sql_schema;
+        let result = infer_and_apply(test_setup, api, &dm1).sql_schema;
         let index = result
             .table_bang("A")
             .indices
@@ -1009,7 +1012,7 @@ fn removing_multi_field_unique_index_must_work() {
                 secondField Int
             }
         "#;
-        let result = infer_and_apply(api, &dm2).sql_schema;
+        let result = dbg!(infer_and_apply(test_setup, api, &dm2).sql_schema);
         let index = result
             .table_bang("A")
             .indices
@@ -1266,7 +1269,7 @@ fn dropping_a_model_with_a_multi_field_unique_index_must_work() {
 
 #[test]
 fn adding_a_scalar_list_for_a_modelwith_id_type_int_must_work() {
-    test_each_connector(|sql_family, api| {
+    test_each_connector(|test_setup, api| {
         let dm1 = r#"
             model A {
                 id Int @id
@@ -1279,7 +1282,7 @@ fn adding_a_scalar_list_for_a_modelwith_id_type_int_must_work() {
               ERROR
             }
         "#;
-        let result = infer_and_apply(api, &dm1).sql_schema;
+        let result = infer_and_apply(test_setup, api, &dm1).sql_schema;
         let scalar_list_table_for_strings = result.table_bang("A_strings");
         let node_id_column = scalar_list_table_for_strings.column_bang("nodeId");
         assert_eq!(node_id_column.tpe.family, ColumnTypeFamily::Int);
@@ -1299,14 +1302,14 @@ fn adding_a_scalar_list_for_a_modelwith_id_type_int_must_work() {
 
 #[test]
 fn updating_a_model_with_a_scalar_list_to_a_different_id_type_must_work() {
-    test_each_connector_with_ignores(vec![SqlFamily::Mysql], |_, api| {
+    test_each_connector_with_ignores(vec![SqlFamily::Mysql], |test_setup, api| {
         let dm = r#"
             model A {
                 id Int @id
                 strings String[]
             }
         "#;
-        let result = infer_and_apply(api, &dm).sql_schema;
+        let result = infer_and_apply(test_setup, api, &dm).sql_schema;
         let node_id_column = result.table_bang("A_strings").column_bang("nodeId");
         assert_eq!(node_id_column.tpe.family, ColumnTypeFamily::Int);
 
@@ -1316,7 +1319,7 @@ fn updating_a_model_with_a_scalar_list_to_a_different_id_type_must_work() {
                 strings String[]
             }
         "#;
-        let result = infer_and_apply(api, &dm).sql_schema;
+        let result = infer_and_apply(test_setup, api, &dm).sql_schema;
         let node_id_column = result.table_bang("A_strings").column_bang("nodeId");
         assert_eq!(node_id_column.tpe.family, ColumnTypeFamily::String);
     });
@@ -1325,7 +1328,7 @@ fn updating_a_model_with_a_scalar_list_to_a_different_id_type_must_work() {
 #[test]
 fn reserved_sql_key_words_must_work() {
     // Group is a reserved keyword
-    test_each_connector(|sql_family, api| {
+    test_each_connector(|test_setup, api| {
         let dm = r#"
             model Group {
                 id    String  @default(cuid()) @id
@@ -1333,7 +1336,7 @@ fn reserved_sql_key_words_must_work() {
                 childGroups Group[] @relation(name: "ChildGroups")
             }
         "#;
-        let result = infer_and_apply(api, &dm).sql_schema;
+        let result = infer_and_apply(test_setup, api, &dm).sql_schema;
 
         let table = result.table_bang("Group");
         let relation_column = table.column_bang("parent");

--- a/migration-engine/core/tests/test_harness/command_helpers.rs
+++ b/migration-engine/core/tests/test_harness/command_helpers.rs
@@ -1,4 +1,4 @@
-use super::introspect_database;
+use super::{introspect_database, TestSetup};
 use migration_connector::*;
 use migration_core::{api::GenericApi, commands::*};
 use sql_migration_connector::SqlMigrationStep;
@@ -25,6 +25,7 @@ pub fn infer_and_apply(api: &dyn GenericApi, datamodel: &str) -> InferAndApplyOu
 }
 
 pub fn infer_and_apply_with_migration_id(
+    test_setup: &TestSetup,
     api: &dyn GenericApi,
     datamodel: &str,
     migration_id: &str,
@@ -37,7 +38,7 @@ pub fn infer_and_apply_with_migration_id(
 
     let steps = run_infer_command(api, input);
 
-    apply_migration(api, steps, migration_id)
+    apply_migration(test_setup, api, steps, migration_id)
 }
 
 pub fn run_infer_command(api: &dyn GenericApi, input: InferMigrationStepsInput) -> Vec<MigrationStep> {
@@ -51,7 +52,12 @@ pub fn run_infer_command(api: &dyn GenericApi, input: InferMigrationStepsInput) 
     output.datamodel_steps
 }
 
-pub fn apply_migration(api: &dyn GenericApi, steps: Vec<MigrationStep>, migration_id: &str) -> InferAndApplyOutput {
+pub fn apply_migration(
+    test_setup: &TestSetup,
+    api: &dyn GenericApi,
+    steps: Vec<MigrationStep>,
+    migration_id: &str,
+) -> InferAndApplyOutput {
     let input = ApplyMigrationInput {
         migration_id: migration_id.to_string(),
         steps: steps,
@@ -69,14 +75,14 @@ pub fn apply_migration(api: &dyn GenericApi, steps: Vec<MigrationStep>, migratio
     );
 
     InferAndApplyOutput {
-        sql_schema: introspect_database(api),
+        sql_schema: introspect_database(test_setup, api),
         migration_output,
     }
 }
 
-pub fn unapply_migration(api: &dyn GenericApi) -> SqlSchema {
+pub fn unapply_migration(test_setup: &TestSetup, api: &dyn GenericApi) -> SqlSchema {
     let input = UnapplyMigrationInput {};
     let _ = api.unapply_migration(&input);
 
-    introspect_database(api)
+    introspect_database(test_setup, api)
 }

--- a/migration-engine/core/tests/test_harness/command_helpers.rs
+++ b/migration-engine/core/tests/test_harness/command_helpers.rs
@@ -20,8 +20,8 @@ impl InferAndApplyOutput {
     }
 }
 
-pub fn infer_and_apply(api: &dyn GenericApi, datamodel: &str) -> InferAndApplyOutput {
-    infer_and_apply_with_migration_id(api, &datamodel, "the-migration-id")
+pub fn infer_and_apply(test_setup: &TestSetup, api: &dyn GenericApi, datamodel: &str) -> InferAndApplyOutput {
+    infer_and_apply_with_migration_id(test_setup, api, &datamodel, "the-migration-id")
 }
 
 pub fn infer_and_apply_with_migration_id(

--- a/migration-engine/core/tests/test_harness/misc_helpers.rs
+++ b/migration-engine/core/tests/test_harness/misc_helpers.rs
@@ -321,10 +321,12 @@ pub fn mysql_url() -> String {
 }
 
 pub fn mysql_8_url() -> String {
+    let (host, port) = db_host_and_port_mysql_8_0();
     dbg!(format!(
-        "mysql://root:prisma@{}:3307/{}",
-        db_host_mysql_8_0(),
-        SCHEMA_NAME
+        "mysql://root:prisma@{host}:{port}/{schema_name}",
+        host = host,
+        port = port,
+        schema_name = SCHEMA_NAME
     ))
 }
 
@@ -335,10 +337,10 @@ fn db_host_postgres() -> String {
     }
 }
 
-fn db_host_mysql_8_0() -> String {
+fn db_host_and_port_mysql_8_0() -> (String, usize) {
     match std::env::var("IS_BUILDKITE") {
-        Ok(_) => "test-db-mysql-8-0".to_string(),
-        Err(_) => "127.0.0.1".to_string(),
+        Ok(_) => ("test-db-mysql-8-0".to_string(), 3306),
+        Err(_) => ("127.0.0.1".to_string(), 3307),
     }
 }
 

--- a/migration-engine/core/tests/test_harness/misc_helpers.rs
+++ b/migration-engine/core/tests/test_harness/misc_helpers.rs
@@ -313,11 +313,19 @@ pub fn postgres_url() -> String {
 }
 
 pub fn mysql_url() -> String {
-    dbg!(format!("mysql://root:prisma@{}:3306/{}", db_host_mysql(), SCHEMA_NAME))
+    dbg!(format!(
+        "mysql://root:prisma@{}:3306/{}",
+        db_host_mysql_5_7(),
+        SCHEMA_NAME
+    ))
 }
 
 pub fn mysql_8_url() -> String {
-    dbg!(format!("mysql://root:prisma@{}:3307/{}", db_host_mysql(), SCHEMA_NAME))
+    dbg!(format!(
+        "mysql://root:prisma@{}:3307/{}",
+        db_host_mysql_8_0(),
+        SCHEMA_NAME
+    ))
 }
 
 fn db_host_postgres() -> String {
@@ -327,9 +335,16 @@ fn db_host_postgres() -> String {
     }
 }
 
-fn db_host_mysql() -> String {
+fn db_host_mysql_8_0() -> String {
     match std::env::var("IS_BUILDKITE") {
-        Ok(_) => "test-db-mysql".to_string(),
+        Ok(_) => "test-db-mysql-8-0".to_string(),
+        Err(_) => "127.0.0.1".to_string(),
+    }
+}
+
+fn db_host_mysql_5_7() -> String {
+    match std::env::var("IS_BUILDKITE") {
+        Ok(_) => "test-db-mysql-5-7".to_string(),
         Err(_) => "127.0.0.1".to_string(),
     }
 }

--- a/migration-engine/core/tests/unapply_migration_tests.rs
+++ b/migration-engine/core/tests/unapply_migration_tests.rs
@@ -6,7 +6,7 @@ use test_harness::*;
 
 #[test]
 fn unapply_must_work() {
-    test_each_connector(|_, api| {
+    test_each_connector(|test_setup, api| {
         let dm1 = r#"
             model Test {
                 id String @id @default(cuid())
@@ -14,7 +14,7 @@ fn unapply_must_work() {
             }
         "#;
 
-        let result1 = infer_and_apply(api, &dm1).sql_schema;
+        let result1 = infer_and_apply(test_setup, api, &dm1).sql_schema;
         assert_eq!(result1.table_bang("Test").column("field").is_some(), true);
 
         let dm2 = r#"
@@ -23,14 +23,14 @@ fn unapply_must_work() {
             }
         "#;
 
-        let result2 = infer_and_apply(api, &dm2).sql_schema;
+        let result2 = infer_and_apply(test_setup, api, &dm2).sql_schema;
         assert_eq!(result2.table_bang("Test").column("field").is_some(), false);
 
-        let result3 = unapply_migration(api);
+        let result3 = unapply_migration(test_setup, api);
         assert_eq!(result1, result3);
 
         // reapply the migration again
-        let result4 = infer_and_apply(api, &dm2).sql_schema;
+        let result4 = infer_and_apply(test_setup, api, &dm2).sql_schema;
         assert_eq!(result2, result4);
     });
 }

--- a/query-engine/connector-test-kit/src/test/scala/util/ConnectorConfig.scala
+++ b/query-engine/connector-test-kit/src/test/scala/util/ConnectorConfig.scala
@@ -38,7 +38,7 @@ object ConnectorConfig {
 
   lazy val mysqlHost = {
     if (EnvVars.isBuildkite) {
-      "test-db-mysql"
+      "test-db-mysql-5-7"
     } else {
       "127.0.0.1"
     }


### PR DESCRIPTION
In queries, the column names are case-insensitive, but in the ResultSets
we get column names with their original case, which changed in MySQL 8.

Someone had the same problem on Stackoverflow:

https://stackoverflow.com/questions/54538448/what-are-the-changes-in-mysql-8-result-rowset-case

---

This fix works, but it feels like there could be a better, more general solution to that column name case sensitivity issue, what do you think? Maybe making accessing a column by name in a ResultSet in prisma-query case-insensitive.