### PR TITLE
Handle the absence of `postgres` database when creating user db

### DIFF
--- a/migration-engine/connectors/migration-connector/src/error.rs
+++ b/migration-engine/connectors/migration-connector/src/error.rs
@@ -17,6 +17,9 @@ pub enum ConnectorError {
     #[fail(display = "Database '{}' already exists", db_name)]
     DatabaseAlreadyExists { db_name: String },
 
+    #[fail(display = "Could not create the database. {}", explanation)]
+    DatabaseCreationFailed { explanation: String },
+
     #[fail(display = "Authentication failed for user '{}'", user)]
     AuthenticationFailed { user: String },
 

--- a/migration-engine/connectors/sql-migration-connector/src/migration_database.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/migration_database.rs
@@ -3,7 +3,12 @@ use prisma_query::{
     connector::{self, MysqlParams, PostgresParams, Queryable, ResultSet, SqliteParams},
     pool::{mysql::*, postgres::*, sqlite::*, PrismaConnectionManager},
 };
-use std::{sync::{Arc, Mutex}, convert::TryFrom, ops::DerefMut, time::Duration};
+use std::{
+    convert::TryFrom,
+    ops::DerefMut,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 pub trait MigrationDatabase: Send + Sync + 'static {
     fn execute(&self, db: &str, q: Query) -> prisma_query::Result<Option<Id>>;
@@ -94,7 +99,7 @@ impl MigrationDatabase for Sqlite {
 
 enum PostgresConnection {
     Pooled(PostgresPool),
-    Single(Mutex<connector::PostgreSql>)
+    Single(Mutex<connector::PostgreSql>),
 }
 
 pub struct PostgreSql {
@@ -126,9 +131,7 @@ impl PostgreSql {
         F: FnOnce(&mut dyn Queryable) -> T,
     {
         match self.conn {
-            PostgresConnection::Single(ref mutex) => {
-                f(mutex.lock().unwrap().deref_mut())
-            },
+            PostgresConnection::Single(ref mutex) => f(mutex.lock().unwrap().deref_mut()),
             PostgresConnection::Pooled(ref pool) => {
                 let mut conn = pool.get().unwrap();
                 f(conn.deref_mut())
@@ -157,7 +160,7 @@ impl MigrationDatabase for PostgreSql {
 
 enum MysqlConnection {
     Pooled(MysqlPool),
-    Single(Mutex<connector::Mysql>)
+    Single(Mutex<connector::Mysql>),
 }
 
 pub struct Mysql {
@@ -189,9 +192,7 @@ impl Mysql {
         F: FnOnce(&mut dyn Queryable) -> T,
     {
         match self.conn {
-            MysqlConnection::Single(ref mutex) => {
-                f(mutex.lock().unwrap().deref_mut())
-            },
+            MysqlConnection::Single(ref mutex) => f(mutex.lock().unwrap().deref_mut()),
             MysqlConnection::Pooled(ref pool) => {
                 let mut conn = pool.get().unwrap();
                 f(conn.deref_mut())

--- a/migration-engine/core/src/cli.rs
+++ b/migration-engine/core/src/cli.rs
@@ -136,9 +136,9 @@ fn create_postgres_admin_conn(mut url: Url) -> crate::Result<SqlMigrationConnect
         })
         .next()
         .ok_or_else(|| {
-            ConnectorError::Generic(failure::format_err!(
-                "Prisma could not connect to a default database (`postgres` or `template1`), it cannot create the specified database."
-            ))
+            ConnectorError::DatabaseCreationFailed {
+                explanation: "Prisma could not connect to a default database (`postgres` or `template1`), it cannot create the specified database.".to_owned()
+            }
         })??;
 
     Ok(inner)


### PR DESCRIPTION
A postgres connection needs to be to a specific database (there is no
universal default, although `postgres` is a common one). We now try to
connect to `postgres`, `template1` (it should always be present), then
fail with a more descriptive error.