### PR TITLE
Fix the serialization of arguments on model unique index directives

### DIFF
--- a/libs/datamodel/src/dml/validator/directive/core/unique.rs
+++ b/libs/datamodel/src/dml/validator/directive/core/unique.rs
@@ -92,9 +92,6 @@ impl DirectiveValidator<dml::Model> for ModelLevelUniqueValidator {
             .map(|index_def| {
                 let mut args = Vec::new();
 
-                if let Some(name) = &index_def.name {
-                    args.push(ast::Argument::new_string("name", &name));
-                }
                 args.push(ast::Argument::new_array(
                     "",
                     index_def
@@ -103,6 +100,10 @@ impl DirectiveValidator<dml::Model> for ModelLevelUniqueValidator {
                         .map(|f| ast::Value::ConstantValue(f.to_string(), ast::Span::empty()))
                         .collect(),
                 ));
+
+                if let Some(name) = &index_def.name {
+                    args.push(ast::Argument::new_string("name", &name));
+                }
 
                 ast::Directive::new(self.directive_name(), args)
             })

--- a/libs/datamodel/tests/directives/unique.rs
+++ b/libs/datamodel/tests/directives/unique.rs
@@ -1,4 +1,4 @@
-use datamodel::{ast::Span, common::PrismaType, dml, errors::*, IndexDefinition};
+use datamodel::{ast::Span, errors::*, render_to_string, IndexDefinition};
 
 use crate::common::*;
 
@@ -90,4 +90,20 @@ fn must_error_when_unknown_fields_are_used() {
         "User",
         Span::new(56, 73),
     ));
+}
+
+#[test]
+fn unique_directives_must_serialize_to_valid_dml() {
+    let dml = r#"
+        model User {
+            id        Int    @id
+            firstName String
+            lastName  String
+
+            @@unique([firstName,lastName], name: "customName")
+        }
+    "#;
+    let schema = parse(dml);
+
+    assert!(datamodel::parse(&render_to_string(&schema).unwrap()).is_ok());
 }


### PR DESCRIPTION
Before, the directive would be serialized as `@@unique(name: "customName", [firstName, lastName])`. This did not pass validation when re-ingesting the schema; this commit changes it to `@@unique([firstName, lastName], name: "customName")`.