### PR TITLE
Rename DatabaseSchemaDiffer and DatabaseSchemaCalculator

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -3,8 +3,6 @@ extern crate log;
 
 pub mod migration_database;
 
-mod database_schema_calculator;
-mod database_schema_differ;
 mod error;
 mod sql_database_migration_inferrer;
 mod sql_database_step_applier;
@@ -12,6 +10,8 @@ mod sql_destructive_changes_checker;
 mod sql_migration;
 mod sql_migration_persistence;
 mod sql_renderer;
+mod sql_schema_calculator;
+mod sql_schema_differ;
 
 pub use error::*;
 pub use sql_migration::*;

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
@@ -6,13 +6,13 @@ use itertools::Itertools;
 use prisma_models::{DatamodelConverter, TempManifestationHolder, TempRelationHolder};
 use sql_schema_describer as sql;
 
-pub struct DatabaseSchemaCalculator<'a> {
+pub struct SqlSchemaCalculator<'a> {
     data_model: &'a Datamodel,
 }
 
-impl<'a> DatabaseSchemaCalculator<'a> {
+impl<'a> SqlSchemaCalculator<'a> {
     pub fn calculate(data_model: &Datamodel) -> SqlResult<sql::SqlSchema> {
-        let calculator = DatabaseSchemaCalculator { data_model };
+        let calculator = SqlSchemaCalculator { data_model };
         calculator.calculate_internal()
     }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
@@ -5,13 +5,13 @@ use sql_schema_describer::*;
 const MIGRATION_TABLE_NAME: &str = "_Migration";
 
 #[derive(Debug)]
-pub struct DatabaseSchemaDiffer<'a> {
+pub struct SqlSchemaDiffer<'a> {
     previous: &'a SqlSchema,
     next: &'a SqlSchema,
 }
 
 #[derive(Debug, Clone)]
-pub struct DatabaseSchemaDiff {
+pub struct SqlSchemaDiff {
     pub drop_tables: Vec<DropTable>,
     pub create_tables: Vec<CreateTable>,
     pub alter_tables: Vec<AlterTable>,
@@ -20,7 +20,7 @@ pub struct DatabaseSchemaDiff {
     pub alter_indexes: Vec<AlterIndex>,
 }
 
-impl DatabaseSchemaDiff {
+impl SqlSchemaDiff {
     pub fn into_steps(self) -> Vec<SqlMigrationStep> {
         let mut steps = Vec::new();
         steps.append(&mut wrap_as_step(self.drop_indexes, |x| SqlMigrationStep::DropIndex(x)));
@@ -41,15 +41,16 @@ impl DatabaseSchemaDiff {
     }
 }
 
-impl<'a> DatabaseSchemaDiffer<'a> {
-    pub fn diff(previous: &SqlSchema, next: &SqlSchema) -> DatabaseSchemaDiff {
-        let differ = DatabaseSchemaDiffer { previous, next };
+impl<'a> SqlSchemaDiffer<'a> {
+    pub fn diff(previous: &SqlSchema, next: &SqlSchema) -> SqlSchemaDiff {
+        let differ = SqlSchemaDiffer { previous, next };
         differ.diff_internal()
     }
 
-    fn diff_internal(&self) -> DatabaseSchemaDiff {
+    fn diff_internal(&self) -> SqlSchemaDiff {
         let alter_indexes = self.alter_indexes();
-        DatabaseSchemaDiff {
+
+        SqlSchemaDiff {
             drop_tables: self.drop_tables(),
             create_tables: self.create_tables(),
             alter_tables: self.alter_tables(),


### PR DESCRIPTION
They are SQL specific, so let's rename them to SqlSchemaDiffer and SqlSchemaCalculator.