### PR TITLE
[migration-engine] Fix foreign key column drops on mysql

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/tests/introspection_command_tests.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/tests/introspection_command_tests.rs
@@ -822,6 +822,7 @@ fn foreign_keys_are_preserved_when_generating_data_model_from_a_schema() {
                 indices: vec![],
                 primary_key: None,
                 foreign_keys: vec![ForeignKey {
+                    constraint_name: None,
                     columns: vec!["city-id".to_string(), "city-name".to_string()],
                     referenced_table: "City".to_string(),
                     on_delete_action: ForeignKeyAction::NoAction,

--- a/libs/sql-schema-describer/src/lib.rs
+++ b/libs/sql-schema-describer/src/lib.rs
@@ -332,6 +332,8 @@ pub enum ForeignKeyAction {
 #[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ForeignKey {
+    /// The database name of the foreign key constraint, when available.
+    pub constraint_name: Option<String>,
     /// Column names.
     pub columns: Vec<String>,
     /// Referenced table.

--- a/libs/sql-schema-describer/src/mysql.rs
+++ b/libs/sql-schema-describer/src/mysql.rs
@@ -199,6 +199,7 @@ impl SqlSchemaDescriber {
                 }
                 None => {
                     let fk = ForeignKey {
+                        constraint_name: Some(constraint_name.clone()),
                         columns: vec![column],
                         referenced_table,
                         referenced_columns: vec![referenced_column],

--- a/libs/sql-schema-describer/src/sqlite.rs
+++ b/libs/sql-schema-describer/src/sqlite.rs
@@ -239,6 +239,10 @@ impl SqlSchemaDescriber {
                     referenced_table: intermediate_fk.referenced_table.to_owned(),
                     referenced_columns,
                     on_delete_action: intermediate_fk.on_delete_action.to_owned(),
+
+                    // Not relevant in SQLite since we cannot ALTER or DROP foreign keys by
+                    // constraint name.
+                    constraint_name: None,
                 };
                 debug!("Detected foreign key {:?}", fk);
                 fk

--- a/libs/sql-schema-describer/tests/introspection_tests.rs
+++ b/libs/sql-schema-describer/tests/introspection_tests.rs
@@ -122,6 +122,11 @@ fn foreign_keys_must_work() {
                     indices: vec![],
                     primary_key: None,
                     foreign_keys: vec![ForeignKey {
+                        constraint_name: match db_type {
+                            DbType::Postgres => Some("User_city_fkey".to_owned()),
+                            DbType::MySql => Some("User_ibfk_1".to_owned()),
+                            DbType::Sqlite => None,
+                        },
                         columns: vec!["city".to_string()],
                         referenced_columns: vec!["id".to_string()],
                         referenced_table: "City".to_string(),
@@ -202,6 +207,11 @@ fn multi_column_foreign_keys_must_work() {
                     indices: vec![],
                     primary_key: None,
                     foreign_keys: vec![ForeignKey {
+                        constraint_name: match db_type {
+                            DbType::Postgres => Some("User_city_fkey".to_owned()),
+                            DbType::MySql => Some("User_ibfk_1".to_owned()),
+                            DbType::Sqlite => None,
+                        },
                         columns: vec!["city".to_string(), "city_name".to_string()],
                         referenced_columns: vec!["id".to_string(), "name".to_string()],
                         referenced_table: "City".to_string(),

--- a/libs/sql-schema-describer/tests/mysql_introspection_tests.rs
+++ b/libs/sql-schema-describer/tests/mysql_introspection_tests.rs
@@ -545,24 +545,28 @@ fn mysql_foreign_key_on_delete_must_be_handled() {
             }),
             foreign_keys: vec![
                 ForeignKey {
+                    constraint_name: Some("User_ibfk_1".to_owned()),
                     columns: vec!["city".to_string()],
                     referenced_columns: vec!["id".to_string()],
                     referenced_table: "City".to_string(),
                     on_delete_action: ForeignKeyAction::NoAction,
                 },
                 ForeignKey {
+                    constraint_name: Some("User_ibfk_2".to_owned()),
                     columns: vec!["city_cascade".to_string()],
                     referenced_columns: vec!["id".to_string()],
                     referenced_table: "City".to_string(),
                     on_delete_action: ForeignKeyAction::Cascade,
                 },
                 ForeignKey {
+                    constraint_name: Some("User_ibfk_3".to_owned()),
                     columns: vec!["city_restrict".to_string()],
                     referenced_columns: vec!["id".to_string()],
                     referenced_table: "City".to_string(),
                     on_delete_action: ForeignKeyAction::Restrict,
                 },
                 ForeignKey {
+                    constraint_name: Some("User_ibfk_4".to_owned()),
                     columns: vec!["city_set_null".to_string()],
                     referenced_columns: vec!["id".to_string()],
                     referenced_table: "City".to_string(),

--- a/libs/sql-schema-describer/tests/postgres_introspection_tests.rs
+++ b/libs/sql-schema-describer/tests/postgres_introspection_tests.rs
@@ -640,30 +640,35 @@ fn postgres_foreign_key_on_delete_must_be_handled() {
             }),
             foreign_keys: vec![
                 ForeignKey {
+                    constraint_name: Some("User_city_fkey".to_owned()),
                     columns: vec!["city".into()],
                     referenced_columns: vec!["id".into()],
                     referenced_table: "City".into(),
                     on_delete_action: ForeignKeyAction::NoAction,
                 },
                 ForeignKey {
+                    constraint_name: Some("User_city_cascade_fkey".to_owned()),
                     columns: vec!["city_cascade".into()],
                     referenced_columns: vec!["id".into()],
                     referenced_table: "City".into(),
                     on_delete_action: ForeignKeyAction::Cascade,
                 },
                 ForeignKey {
+                    constraint_name: Some("User_city_restrict_fkey".to_owned()),
                     columns: vec!["city_restrict".into()],
                     referenced_columns: vec!["id".into()],
                     referenced_table: "City".into(),
                     on_delete_action: ForeignKeyAction::Restrict,
                 },
                 ForeignKey {
+                    constraint_name: Some("User_city_set_default_fkey".to_owned()),
                     columns: vec!["city_set_default".into()],
                     referenced_columns: vec!["id".into()],
                     referenced_table: "City".into(),
                     on_delete_action: ForeignKeyAction::SetDefault,
                 },
                 ForeignKey {
+                    constraint_name: Some("User_city_set_null_fkey".to_owned()),
                     columns: vec!["city_set_null".into()],
                     referenced_columns: vec!["id".into()],
                     referenced_table: "City".into(),

--- a/libs/sql-schema-describer/tests/serialization_tests.rs
+++ b/libs/sql-schema-describer/tests/serialization_tests.rs
@@ -100,6 +100,7 @@ fn database_schema_is_serializable() {
                     sequence: None,
                 }),
                 foreign_keys: vec![ForeignKey {
+                    constraint_name: None,
                     columns: vec!["column3".to_string()],
                     referenced_table: "table2".to_string(),
                     referenced_columns: vec!["id".to_string()],
@@ -345,30 +346,35 @@ fn database_schema_is_serializable_for_every_foreign_key_action() {
             primary_key: None,
             foreign_keys: vec![
                 ForeignKey {
+                    constraint_name: None,
                     columns: vec!["column1".to_string()],
                     referenced_table: "table2".to_string(),
                     referenced_columns: vec!["id".to_string()],
                     on_delete_action: ForeignKeyAction::NoAction,
                 },
                 ForeignKey {
+                    constraint_name: None,
                     columns: vec!["column2".to_string()],
                     referenced_table: "table2".to_string(),
                     referenced_columns: vec!["id".to_string()],
                     on_delete_action: ForeignKeyAction::Restrict,
                 },
                 ForeignKey {
+                    constraint_name: None,
                     columns: vec!["column3".to_string()],
                     referenced_table: "table2".to_string(),
                     referenced_columns: vec!["id".to_string()],
                     on_delete_action: ForeignKeyAction::Cascade,
                 },
                 ForeignKey {
+                    constraint_name: None,
                     columns: vec!["column4".to_string()],
                     referenced_table: "table2".to_string(),
                     referenced_columns: vec!["id".to_string()],
                     on_delete_action: ForeignKeyAction::SetNull,
                 },
                 ForeignKey {
+                    constraint_name: None,
                     columns: vec!["column5".to_string()],
                     referenced_table: "table2".to_string(),
                     referenced_columns: vec!["id".to_string()],

--- a/libs/sql-schema-describer/tests/sqlite_introspection_tests.rs
+++ b/libs/sql-schema-describer/tests/sqlite_introspection_tests.rs
@@ -178,30 +178,35 @@ fn sqlite_foreign_key_on_delete_must_be_handled() {
             }),
             foreign_keys: vec![
                 ForeignKey {
+                    constraint_name: None,
                     columns: vec!["city".to_string()],
                     referenced_columns: vec!["id".to_string()],
                     referenced_table: "City".to_string(),
                     on_delete_action: ForeignKeyAction::NoAction,
                 },
                 ForeignKey {
+                    constraint_name: None,
                     columns: vec!["city_cascade".to_string()],
                     referenced_columns: vec!["id".to_string()],
                     referenced_table: "City".to_string(),
                     on_delete_action: ForeignKeyAction::Cascade,
                 },
                 ForeignKey {
+                    constraint_name: None,
                     columns: vec!["city_restrict".to_string()],
                     referenced_columns: vec!["id".to_string()],
                     referenced_table: "City".to_string(),
                     on_delete_action: ForeignKeyAction::Restrict,
                 },
                 ForeignKey {
+                    constraint_name: None,
                     columns: vec!["city_set_default".to_string()],
                     referenced_columns: vec!["id".to_string()],
                     referenced_table: "City".to_string(),
                     on_delete_action: ForeignKeyAction::SetDefault,
                 },
                 ForeignKey {
+                    constraint_name: None,
                     columns: vec!["city_set_null".to_string()],
                     referenced_columns: vec!["id".to_string()],
                     referenced_table: "City".to_string(),

--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_migration_inferrer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_migration_inferrer.rs
@@ -233,7 +233,9 @@ fn needs_fix(alter_table: &AlterTable) -> bool {
         }
         TableChange::DropColumn(_) => true,
         TableChange::AlterColumn(_) => true,
+        TableChange::DropForeignKey(_) => true,
     });
+
     change_that_does_not_work_on_sqlite.is_some()
 }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -141,6 +141,13 @@ fn render_raw_sql(step: &SqlMigrationStep, sql_family: SqlFamily, schema_name: &
                         let col_sql = renderer.render_column(&schema_name, &table, &column, true);
                         lines.push(format!("ADD COLUMN {}", col_sql));
                     }
+                    TableChange::DropForeignKey(DropForeignKey { constraint_name }) => match sql_family {
+                        SqlFamily::Mysql => {
+                            let constraint_name = renderer.quote(&constraint_name);
+                            lines.push(format!("DROP FOREIGN KEY {}", constraint_name));
+                        }
+                        _ => (),
+                    },
                 }
             }
             format!(

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
@@ -71,6 +71,9 @@ pub enum TableChange {
     AddColumn(AddColumn),
     AlterColumn(AlterColumn),
     DropColumn(DropColumn),
+    /// This is actually producing SQL only on MySQL, where we have to drop the foreign key
+    /// constraint before any column that is part of it.
+    DropForeignKey(DropForeignKey),
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
@@ -87,6 +90,11 @@ pub struct DropColumn {
 pub struct AlterColumn {
     pub name: String,
     pub column: Column,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct DropForeignKey {
+    pub constraint_name: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
@@ -142,6 +142,7 @@ impl<'a> SqlSchemaCalculator<'a> {
                     sequence: None,
                 };
                 let foreign_keys = vec![sql::ForeignKey {
+                    constraint_name: None,
                     columns: vec!["nodeId".to_string()],
                     referenced_table: model.db_name(),
                     referenced_columns: vec![model.id_field()?.db_name()],
@@ -200,6 +201,7 @@ impl<'a> SqlSchemaCalculator<'a> {
                         };
                         let field = model.fields().find(|f| &f.db_name() == column).unwrap();
                         let foreign_key = sql::ForeignKey {
+                            constraint_name: None,
                             columns: vec![column.to_string()],
                             referenced_table: related_model.db_name(),
                             referenced_columns: vec![related_model.id_field()?.db_name()],
@@ -230,12 +232,14 @@ impl<'a> SqlSchemaCalculator<'a> {
                 TempManifestationHolder::Table => {
                     let foreign_keys = vec![
                         sql::ForeignKey {
+                            constraint_name: None,
                             columns: vec![relation.model_a_column()],
                             referenced_table: relation.model_a.db_name(),
                             referenced_columns: vec![relation.model_a.id_field()?.db_name()],
                             on_delete_action: sql::ForeignKeyAction::Cascade,
                         },
                         sql::ForeignKey {
+                            constraint_name: None,
                             columns: vec![relation.model_b_column()],
                             referenced_table: relation.model_b.db_name(),
                             referenced_columns: vec![relation.model_b.id_field()?.db_name()],

--- a/migration-engine/core/tests/existing_databases_tests.rs
+++ b/migration-engine/core/tests/existing_databases_tests.rs
@@ -161,7 +161,7 @@ fn creating_a_scalar_list_field_for_an_existing_table_must_work() {
         for table in &mut result.tables {
             if table.name == "Blog_tags" {
                 for fk in &mut table.foreign_keys {
-                    if fk.columns == vec!["nodeId".to_string()] {
+                    if fk.columns == &["nodeId"] {
                         fk.on_delete_action = ForeignKeyAction::Cascade
                     }
                 }

--- a/migration-engine/core/tests/migration_tests.rs
+++ b/migration-engine/core/tests/migration_tests.rs
@@ -2,7 +2,7 @@
 #![allow(unused)]
 mod test_harness;
 use pretty_assertions::{assert_eq, assert_ne};
-use sql_migration_connector::{AlterIndex, DropIndex, CreateIndex, SqlFamily, SqlMigrationStep};
+use sql_migration_connector::{AlterIndex, CreateIndex, DropIndex, SqlFamily, SqlMigrationStep};
 use sql_schema_describer::*;
 use test_harness::*;
 
@@ -230,7 +230,12 @@ fn changing_the_type_of_an_id_field_must_work() {
         assert_eq!(column.tpe.family, ColumnTypeFamily::Int);
         assert_eq!(
             table.foreign_keys,
-            vec![ForeignKey {
+            &[ForeignKey {
+                constraint_name: match sql_family {
+                    SqlFamily::Postgres => Some("A_b_fkey".to_owned()),
+                    SqlFamily::Mysql => Some("A_ibfk_1".to_owned()),
+                    SqlFamily::Sqlite => None,
+                },
                 columns: vec![column.name.clone()],
                 referenced_table: "B".to_string(),
                 referenced_columns: vec!["id".to_string()],
@@ -253,7 +258,12 @@ fn changing_the_type_of_an_id_field_must_work() {
         assert_eq!(column.tpe.family, ColumnTypeFamily::String);
         assert_eq!(
             table.foreign_keys,
-            vec![ForeignKey {
+            &[ForeignKey {
+                constraint_name: match sql_family {
+                    SqlFamily::Postgres => Some("A_b_fkey".to_owned()),
+                    SqlFamily::Mysql => Some("A_ibfk_1".to_owned()),
+                    SqlFamily::Sqlite => None,
+                },
                 columns: vec![column.name.clone()],
                 referenced_table: "B".to_string(),
                 referenced_columns: vec!["id".to_string()],
@@ -290,7 +300,7 @@ fn updating_db_name_of_a_scalar_field_must_work() {
 #[test]
 fn changing_a_relation_field_to_a_scalar_field_must_work() {
     // this relies on link: INLINE which we don't support yet
-    test_each_connector_with_ignores(vec![SqlFamily::Mysql], |sql_family, api| {
+    test_each_connector_with_ignores(&[SqlFamily::Mysql], |sql_family, api| {
         let dm1 = r#"
             model A {
                 id Int @id
@@ -307,7 +317,12 @@ fn changing_a_relation_field_to_a_scalar_field_must_work() {
         assert_eq!(column.tpe.family, ColumnTypeFamily::Int);
         assert_eq!(
             table.foreign_keys,
-            vec![ForeignKey {
+            &[ForeignKey {
+                constraint_name: match sql_family {
+                    SqlFamily::Postgres => Some("A_b_fkey".to_owned()),
+                    SqlFamily::Mysql => Some("A_ibfk_1".to_owned()),
+                    SqlFamily::Sqlite => None,
+                },
                 columns: vec![column.name.clone()],
                 referenced_table: "B".to_string(),
                 referenced_columns: vec!["id".to_string()],
@@ -366,7 +381,12 @@ fn changing_a_scalar_field_to_a_relation_field_must_work() {
         assert_eq!(column.tpe.family, ColumnTypeFamily::Int);
         assert_eq!(
             table.foreign_keys,
-            vec![ForeignKey {
+            &[ForeignKey {
+                constraint_name: match sql_family {
+                    SqlFamily::Postgres => Some("A_b_fkey".to_owned()),
+                    SqlFamily::Mysql => Some("A_ibfk_1".to_owned()),
+                    SqlFamily::Sqlite => None,
+                },
                 columns: vec![column.name.clone()],
                 referenced_table: "B".to_string(),
                 referenced_columns: vec!["id".to_string()],
@@ -402,14 +422,24 @@ fn adding_a_many_to_many_relation_must_result_in_a_prisma_style_relation_table()
 
         assert_eq!(
             relation_table.foreign_keys,
-            vec![
+            &[
                 ForeignKey {
+                    constraint_name: match sql_family {
+                        SqlFamily::Postgres => Some("_AToB_A_fkey".to_owned()),
+                        SqlFamily::Mysql => Some("_AToB_ibfk_1".to_owned()),
+                        SqlFamily::Sqlite => None,
+                    },
                     columns: vec![aColumn.name.clone()],
                     referenced_table: "A".to_string(),
                     referenced_columns: vec!["id".to_string()],
                     on_delete_action: ForeignKeyAction::Cascade,
                 },
                 ForeignKey {
+                    constraint_name: match sql_family {
+                        SqlFamily::Postgres => Some("_AToB_B_fkey".to_owned()),
+                        SqlFamily::Mysql => Some("_AToB_ibfk_2".to_owned()),
+                        SqlFamily::Sqlite => None,
+                    },
                     columns: vec![bColumn.name.clone()],
                     referenced_table: "B".to_string(),
                     referenced_columns: vec!["id".to_string()],
@@ -447,12 +477,22 @@ fn adding_a_many_to_many_relation_with_custom_name_must_work() {
             relation_table.foreign_keys,
             vec![
                 ForeignKey {
+                    constraint_name: match sql_family {
+                        SqlFamily::Postgres => Some("_my_relation_A_fkey".to_owned()),
+                        SqlFamily::Mysql => Some("_my_relation_ibfk_1".to_owned()),
+                        SqlFamily::Sqlite => None,
+                    },
                     columns: vec![aColumn.name.clone()],
                     referenced_table: "A".to_string(),
                     referenced_columns: vec!["id".to_string()],
                     on_delete_action: ForeignKeyAction::Cascade,
                 },
                 ForeignKey {
+                    constraint_name: match sql_family {
+                        SqlFamily::Postgres => Some("_my_relation_B_fkey".to_owned()),
+                        SqlFamily::Mysql => Some("_my_relation_ibfk_2".to_owned()),
+                        SqlFamily::Sqlite => None,
+                    },
                     columns: vec![bColumn.name.clone()],
                     referenced_table: "B".to_string(),
                     referenced_columns: vec!["id".to_string()],
@@ -510,7 +550,12 @@ fn adding_an_inline_relation_must_result_in_a_foreign_key_in_the_model_table() {
         assert_eq!(column.tpe.family, ColumnTypeFamily::Int);
         assert_eq!(
             table.foreign_keys,
-            vec![ForeignKey {
+            &[ForeignKey {
+                constraint_name: match sql_family {
+                    SqlFamily::Postgres => Some("A_b_fkey".to_owned()),
+                    SqlFamily::Mysql => Some("A_ibfk_1".to_owned()),
+                    SqlFamily::Sqlite => None,
+                },
                 columns: vec![column.name.clone()],
                 referenced_table: "B".to_string(),
                 referenced_columns: vec!["id".to_string()],
@@ -539,7 +584,12 @@ fn specifying_a_db_name_for_an_inline_relation_must_work() {
         assert_eq!(column.tpe.family, ColumnTypeFamily::Int);
         assert_eq!(
             table.foreign_keys,
-            vec![ForeignKey {
+            &[ForeignKey {
+                constraint_name: match sql_family {
+                    SqlFamily::Postgres => Some("A_b_column_fkey".to_owned()),
+                    SqlFamily::Mysql => Some("A_ibfk_1".to_owned()),
+                    SqlFamily::Sqlite => None,
+                },
                 columns: vec![column.name.clone()],
                 referenced_table: "B".to_string(),
                 referenced_columns: vec!["id".to_string()],
@@ -568,7 +618,12 @@ fn adding_an_inline_relation_to_a_model_with_an_exotic_id_type() {
         assert_eq!(column.tpe.family, ColumnTypeFamily::String);
         assert_eq!(
             table.foreign_keys,
-            vec![ForeignKey {
+            &[ForeignKey {
+                constraint_name: match sql_family {
+                    SqlFamily::Postgres => Some("A_b_fkey".to_owned()),
+                    SqlFamily::Mysql => Some("A_ibfk_1".to_owned()),
+                    SqlFamily::Sqlite => None,
+                },
                 columns: vec![column.name.clone()],
                 referenced_table: "B".to_string(),
                 referenced_columns: vec!["id".to_string()],
@@ -627,7 +682,12 @@ fn moving_an_inline_relation_to_the_other_side_must_work() {
         let table = result.table_bang("A");
         assert_eq!(
             table.foreign_keys,
-            vec![ForeignKey {
+            &[ForeignKey {
+                constraint_name: match sql_family {
+                    SqlFamily::Postgres => Some("A_b_fkey".to_owned()),
+                    SqlFamily::Sqlite => None,
+                    SqlFamily::Mysql => unreachable!(),
+                },
                 columns: vec!["b".to_string()],
                 referenced_table: "B".to_string(),
                 referenced_columns: vec!["id".to_string()],
@@ -649,7 +709,12 @@ fn moving_an_inline_relation_to_the_other_side_must_work() {
         let table = result.table_bang("B");
         assert_eq!(
             table.foreign_keys,
-            vec![ForeignKey {
+            &[ForeignKey {
+                constraint_name: match sql_family {
+                    SqlFamily::Postgres => Some("B_a_fkey".to_owned()),
+                    SqlFamily::Sqlite => None,
+                    SqlFamily::Mysql => unreachable!(),
+                },
                 columns: vec!["a".to_string()],
                 referenced_table: "A".to_string(),
                 referenced_columns: vec!["id".to_string()],
@@ -1163,9 +1228,9 @@ fn index_updates_with_rename_must_work() {
                     index: Index {
                         name: "customNameA".into(),
                         columns: vec!["field".into(), "id".into()],
-                        tpe: IndexType::Unique, 
+                        tpe: IndexType::Unique,
                     },
-                })
+                }),
             ];
             let actual_steps = result.sql_migration();
             assert_eq!(actual_steps, expected_steps);
@@ -1275,6 +1340,11 @@ fn reserved_sql_key_words_must_work() {
         assert_eq!(
             table.foreign_keys,
             vec![ForeignKey {
+                constraint_name: match sql_family {
+                    SqlFamily::Postgres => Some("Group_parent_fkey".to_owned()),
+                    SqlFamily::Mysql => Some("Group_ibfk_1".to_owned()),
+                    SqlFamily::Sqlite => None,
+                },
                 columns: vec!["parent".to_string()],
                 referenced_table: "Group".to_string(),
                 referenced_columns: vec!["id".to_string()],
@@ -1342,5 +1412,53 @@ fn migrations_with_many_to_many_related_models_must_not_recreate_indexes() {
             .find(|index| index.name == "_ProfileToSkill_AB_unique")
             .expect("index is present");
         assert_eq!(index.tpe, IndexType::Unique);
+    })
+}
+
+#[test]
+fn removing_a_relation_field_must_work() {
+    test_each_connector(|sql_family, api| {
+        let dm_1 = r#"
+            model User {
+                id        String  @default(cuid()) @id
+                address   Address @map("address_name")
+            }
+
+            model Address {
+                id        String  @default(cuid()) @id
+                street    String
+            }
+        "#;
+
+        let sql_schema = infer_and_apply(api, &dm_1).sql_schema;
+
+        let address_name_field = sql_schema
+            .table_bang("User")
+            .columns
+            .iter()
+            .find(|col| col.name == "address_name");
+
+        assert!(address_name_field.is_some());
+
+        let dm_2 = r#"
+            model User {
+                id        String  @default(cuid()) @id
+            }
+
+            model Address {
+                id        String  @default(cuid()) @id
+                street    String
+            }
+        "#;
+
+        let sql_schema = infer_and_apply(api, &dm_2).sql_schema;
+
+        let address_name_field = sql_schema
+            .table_bang("User")
+            .columns
+            .iter()
+            .find(|col| col.name == "address_name");
+
+        assert!(address_name_field.is_none());
     })
 }

--- a/migration-engine/core/tests/test_harness/misc_helpers.rs
+++ b/migration-engine/core/tests/test_harness/misc_helpers.rs
@@ -28,16 +28,17 @@ pub fn test_only_connector<F>(sql_family: SqlFamily, test_fn: F)
 where
     F: Fn(SqlFamily, &dyn GenericApi) -> () + std::panic::RefUnwindSafe,
 {
-    let all = vec![SqlFamily::Postgres, SqlFamily::Mysql, SqlFamily::Sqlite];
-    let ignores = all.into_iter().filter(|f| f != &sql_family).collect();
+    let all = &[SqlFamily::Postgres, SqlFamily::Mysql, SqlFamily::Sqlite];
+    let ignores: Vec<SqlFamily> = all.iter().filter(|f| f != &&sql_family).map(|f| *f).collect();
 
     test_each_connector_with_ignores(ignores, test_fn);
 }
 
-pub fn test_each_connector_with_ignores<F>(ignores: Vec<SqlFamily>, test_fn: F)
+pub fn test_each_connector_with_ignores<I: AsRef<[SqlFamily]>, F>(ignores: I, test_fn: F)
 where
     F: Fn(SqlFamily, &dyn GenericApi) -> () + std::panic::RefUnwindSafe,
 {
+    let ignores: &[SqlFamily] = ignores.as_ref();
     // POSTGRES
     if !ignores.contains(&SqlFamily::Postgres) {
         println!("--------------- Testing with Postgres now ---------------");


### PR DESCRIPTION
This PR addresses issue https://github.com/prisma/lift/issues/147

On MySQL, foreign key constraints need to be dropped by name before the
fields they contain. This PR adds the foreign key constraint name to
the introspected SqlSchema, so foreign keys can later be diffed and
dropped.