### PR TITLE
[migration-engine] Report TLS errors separately in migration-engine CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1963,7 +1963,7 @@ dependencies = [
 [[package]]
 name = "prisma-query"
 version = "0.1.0"
-source = "git+https://github.com/prisma/prisma-query.git#b0607ce118e3704879caff8f529eee4ee4a13d96"
+source = "git+https://github.com/prisma/prisma-query.git#7fa8133571f56c8574b52a04dea57f9d4f85f881"
 dependencies = [
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "debug_stub_derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3307,7 +3307,7 @@ name = "twox-hash"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/migration-engine/connectors/migration-connector/src/error.rs
+++ b/migration-engine/connectors/migration-connector/src/error.rs
@@ -28,6 +28,9 @@ pub enum ConnectorError {
 
     #[fail(display = "Operation timed out")]
     Timeout,
+
+    #[fail(display = "Error opening a TLS connection. {}", message)]
+    TlsError { message: String },
 }
 
 impl From<prisma_query::error::Error> for ConnectorError {
@@ -39,6 +42,7 @@ impl From<prisma_query::error::Error> for ConnectorError {
             prisma_query::error::Error::AuthenticationFailed { user } => Self::AuthenticationFailed { user },
             prisma_query::error::Error::ConnectTimeout => Self::ConnectTimeout,
             prisma_query::error::Error::Timeout => Self::Timeout,
+            prisma_query::error::Error::TlsError { message } => Self::TlsError { message },
             e => ConnectorError::QueryError(e.into()),
         }
     }

--- a/migration-engine/connectors/sql-migration-connector/src/error.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/error.rs
@@ -31,6 +31,9 @@ pub enum SqlError {
 
     #[fail(display = "Operation timed out")]
     Timeout,
+
+    #[fail(display = "Error opening a TLS connection. {}", message)]
+    TlsError { message: String },
 }
 
 impl From<SqlError> for ConnectorError {
@@ -42,6 +45,7 @@ impl From<SqlError> for ConnectorError {
             SqlError::AuthenticationFailed { user } => Self::AuthenticationFailed { user },
             SqlError::ConnectTimeout => Self::ConnectTimeout,
             SqlError::Timeout => Self::Timeout,
+            SqlError::TlsError { message } => Self::TlsError { message },
             error => Self::QueryError(error.into()),
         }
     }
@@ -55,6 +59,7 @@ impl From<prisma_query::error::Error> for SqlError {
             prisma_query::error::Error::AuthenticationFailed { user } => Self::AuthenticationFailed { user },
             prisma_query::error::Error::ConnectTimeout => Self::ConnectTimeout,
             prisma_query::error::Error::Timeout => Self::Timeout,
+            prisma_query::error::Error::TlsError { message } => Self::TlsError { message },
             e => SqlError::QueryError(e.into()),
         }
     }

--- a/migration-engine/core/src/cli.rs
+++ b/migration-engine/core/src/cli.rs
@@ -24,6 +24,8 @@ pub enum CliError {
     ConnectTimeout,
     #[fail(display = "Operation timed out")]
     Timeout,
+    #[fail(display = "Error opening a TLS connection. {}", _0)]
+    TlsError(String),
     #[fail(display = "Unknown error occured: {}", _0)]
     Other(String),
 }
@@ -37,6 +39,7 @@ impl From<ConnectorError> for CliError {
             ConnectorError::AuthenticationFailed { user } => CliError::AuthenticationFailed(user),
             ConnectorError::ConnectTimeout => CliError::ConnectTimeout,
             ConnectorError::Timeout => CliError::Timeout,
+            ConnectorError::TlsError { message } => CliError::TlsError(message),
             _ => CliError::ConnectionError,
         }
     }

--- a/migration-engine/core/src/main.rs
+++ b/migration-engine/core/src/main.rs
@@ -133,6 +133,9 @@ fn main() {
                     CliError::DatabaseAlreadyExists(_) => {
                         std::process::exit(5);
                     }
+                    CliError::TlsError(_) => {
+                        std::process::exit(6);
+                    }
                     _ => {
                         std::process::exit(255);
                     }

--- a/query-engine/connectors/sql-query-connector/src/error.rs
+++ b/query-engine/connectors/sql-query-connector/src/error.rs
@@ -159,7 +159,8 @@ impl From<prisma_query::error::Error> for SqlError {
             e @ prisma_query::error::Error::ResultIndexOutOfBounds { .. } => Self::QueryError(e.into()),
             e @ prisma_query::error::Error::ResultTypeMismatch { .. } => Self::QueryError(e.into()),
             e @ prisma_query::error::Error::DatabaseUrlIsInvalid { .. } => Self::ConnectionError(e.into()),
-            e @ prisma_query::error::Error::DatabaseAlreadyExists { .. } => Self::ConnectionError(e.into())
+            e @ prisma_query::error::Error::DatabaseAlreadyExists { .. } => Self::ConnectionError(e.into()),
+            e @ prisma_query::error::Error::TlsError { .. } => Self::ConnectionError(e.into()),
         }
     }
 }


### PR DESCRIPTION
This commit introduces:

- A more specific error message
- A special exit code for TLS errors (6).

Related: https://github.com/prisma/prisma-query/pull/17