### PR TITLE
[migration engine] Drop unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1300,10 +1300,8 @@ dependencies = [
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "datamodel 0.1.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "prisma-query 0.1.0 (git+https://github.com/prisma/prisma-query.git)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1318,7 +1316,6 @@ dependencies = [
  "datamodel 0.1.0",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2732,7 +2729,6 @@ dependencies = [
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "datamodel 0.1.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "migration-connector 0.1.0",

--- a/migration-engine/connectors/migration-connector/Cargo.toml
+++ b/migration-engine/connectors/migration-connector/Cargo.toml
@@ -11,7 +11,5 @@ chrono = { version = "0.4" }
 
 serde = "1.0"
 serde_json = "1.0"
-serde_derive = "1.0"
 
 failure = "0.1"
-failure_derive = "0.1"

--- a/migration-engine/connectors/sql-migration-connector/Cargo.toml
+++ b/migration-engine/connectors/sql-migration-connector/Cargo.toml
@@ -20,5 +20,4 @@ postgres = { version = "0.16.0-rc.1", features = ["with-serde_json-1", "with-chr
 mysql = { version = "*" }
 log = "0.4"
 failure = "0.1"
-failure_derive = "0.1"
 r2d2 = "0.8"

--- a/migration-engine/core/Cargo.toml
+++ b/migration-engine/core/Cargo.toml
@@ -22,7 +22,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 failure = "0.1"
-failure_derive = "0.1"
 
 jsonrpc-core = "13.0"
 jsonrpc-stdio-server = "13.0"


### PR DESCRIPTION
serde-derive is now a feature of serde, and failure_derive is part of failure.