### PR TITLE
Make test_each_connector a proc macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,6 +435,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "darling_core 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "darling_macro 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,6 +456,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,6 +476,16 @@ dependencies = [
  "darling_core 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "darling_core 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1227,6 +1259,7 @@ dependencies = [
  "jsonrpc-stdio-server 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "migration-connector 0.1.0",
+ "migration-engine-macros 0.1.0",
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prisma-models 0.0.0",
  "prisma-query 0.1.0 (git+https://github.com/prisma/prisma-query.git)",
@@ -1238,6 +1271,16 @@ dependencies = [
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "migration-engine-macros"
+version = "0.1.0"
+dependencies = [
+ "darling 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2649,6 +2692,11 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "strsim"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "subtle"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3515,8 +3563,11 @@ dependencies = [
 "checksum crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
 "checksum ctor 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "cd8ce37ad4184ab2ce004c33bf6379185d3b1c95801cab51026bd271bf68eedc"
 "checksum cuid 0.1.0 (git+https://github.com/prisma/cuid-rust)" = "<none>"
+"checksum darling 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
 "checksum darling 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9158d690bc62a3a57c3e45b85e4d50de2008b39345592c64efd79345c7e24be0"
+"checksum darling_core 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
 "checksum darling_core 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)" = "d2a368589465391e127e10c9e3a08efc8df66fd49b87dc8524c764bbe7f2ef82"
+"checksum darling_macro 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 "checksum darling_macro 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)" = "244e8987bd4e174385240cde20a3657f607fb0797563c28255c353b5819a07b1"
 "checksum debug_stub_derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "496b7f8a2f853313c3ca370641d7ff3e42c32974fdccda8f0684599ed0a3ff6b"
 "checksum derive_state_machine_future 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1220ad071cb8996454c20adf547a34ba3ac793759dab793d9dc04996a373ac83"
@@ -3724,6 +3775,7 @@ dependencies = [
 "checksum string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"
 "checksum stringprep 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8ee348cb74b87454fff4b551cbf727025810a004f88aeacae7f85b87f4e9a1c1"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+"checksum strsim 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "032c03039aae92b350aad2e3779c352e104d919cb192ba2fabbd7b831ce4f0f6"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"

--- a/migration-engine/core/Cargo.toml
+++ b/migration-engine/core/Cargo.toml
@@ -36,6 +36,7 @@ prisma-query = { git = "https://github.com/prisma/prisma-query.git" }
 barrel = { version = "0.6.3-alpha.0", features = ["sqlite3", "mysql", "pg"] }
 pretty_assertions = "0.6"
 sql-schema-describer = { path = "../../libs/sql-schema-describer" }
+migration-engine-macros = { path = "../macros" }
 
 [[bin]]
 name = "migration-engine"

--- a/migration-engine/core/tests/test_harness/mod.rs
+++ b/migration-engine/core/tests/test_harness/mod.rs
@@ -3,7 +3,10 @@
 mod command_helpers;
 mod misc_helpers;
 mod step_helpers;
+mod test_api;
 
 pub use command_helpers::*;
+pub use migration_engine_macros::test_each_connector;
 pub use misc_helpers::*;
 pub use step_helpers::*;
+pub use test_api::*;

--- a/migration-engine/core/tests/test_harness/test_api.rs
+++ b/migration-engine/core/tests/test_harness/test_api.rs
@@ -1,0 +1,114 @@
+use super::{
+    misc_helpers::{
+        mysql_8_url, mysql_migration_connector, mysql_url, postgres_migration_connector, postgres_url,
+        sqlite_migration_connector, test_api,
+    },
+    InferAndApplyOutput, SCHEMA_NAME,
+};
+use migration_connector::{MigrationPersistence, MigrationStep};
+use migration_core::{api::GenericApi, commands::ApplyMigrationInput};
+use sql_connection::SyncSqlConnection;
+use sql_migration_connector::SqlFamily;
+use sql_schema_describer::*;
+use std::sync::Arc;
+
+/// A handle to all the context needed for end-to-end testing of the migration engine across
+/// connectors.
+pub struct TestApi {
+    sql_family: SqlFamily,
+    database: Arc<dyn SyncSqlConnection + Send + Sync + 'static>,
+    api: Box<dyn GenericApi>,
+}
+
+impl TestApi {
+    pub fn migration_persistence(&self) -> Arc<dyn MigrationPersistence> {
+        self.api.migration_persistence()
+    }
+
+    pub fn apply_migration(&self, steps: Vec<MigrationStep>, migration_id: &str) -> InferAndApplyOutput {
+        let input = ApplyMigrationInput {
+            migration_id: migration_id.to_string(),
+            steps,
+            force: None,
+        };
+
+        let migration_output = self.api.apply_migration(&input).expect("ApplyMigration failed");
+
+        assert!(
+            migration_output.general_errors.is_empty(),
+            format!(
+                "ApplyMigration returned unexpected errors: {:?}",
+                migration_output.general_errors
+            )
+        );
+
+        InferAndApplyOutput {
+            sql_schema: self.introspect_database(),
+            migration_output,
+        }
+    }
+
+    fn introspect_database(&self) -> SqlSchema {
+        let inspector: Box<dyn SqlSchemaDescriberBackend> = match self.api.connector_type() {
+            "postgresql" => Box::new(sql_schema_describer::postgres::SqlSchemaDescriber::new(Arc::clone(
+                &self.database,
+            ))),
+            "sqlite" => Box::new(sql_schema_describer::sqlite::SqlSchemaDescriber::new(Arc::clone(
+                &self.database,
+            ))),
+            "mysql" => Box::new(sql_schema_describer::mysql::SqlSchemaDescriber::new(Arc::clone(
+                &self.database,
+            ))),
+            _ => unimplemented!(),
+        };
+
+        let mut result = inspector
+            .describe(&SCHEMA_NAME.to_string())
+            .expect("Introspection failed");
+
+        // the presence of the _Migration table makes assertions harder. Therefore remove it from the result.
+        result.tables = result.tables.into_iter().filter(|t| t.name != "_Migration").collect();
+
+        result
+    }
+}
+
+pub fn mysql_8_test_api() -> TestApi {
+    let connector = mysql_migration_connector(&mysql_8_url());
+
+    TestApi {
+        sql_family: SqlFamily::Mysql,
+        database: Arc::clone(&connector.database),
+        api: Box::new(test_api(connector)),
+    }
+}
+
+pub fn mysql_test_api() -> TestApi {
+    let connector = mysql_migration_connector(&mysql_url());
+
+    TestApi {
+        sql_family: SqlFamily::Mysql,
+        database: Arc::clone(&connector.database),
+        api: Box::new(test_api(connector)),
+    }
+}
+
+pub fn postgres_test_api() -> TestApi {
+    let connector = postgres_migration_connector(&postgres_url());
+
+    TestApi {
+        sql_family: SqlFamily::Postgres,
+        database: Arc::clone(&connector.database),
+        api: Box::new(test_api(connector)),
+    }
+}
+
+pub fn sqlite_test_api() -> TestApi {
+    let connector = sqlite_migration_connector();
+
+    TestApi {
+        sql_family: SqlFamily::Sqlite,
+        database: Arc::clone(&connector.database),
+        api: Box::new(test_api(connector)),
+    }
+}

--- a/migration-engine/macros/Cargo.toml
+++ b/migration-engine/macros/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "migration-engine-macros"
+version = "0.1.0"
+authors = ["Tom Houlé <tom@tomhoule.com>"]
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+darling = "0.10.1"
+syn = "1.0.5"
+quote = "1.0.2"
+proc-macro2 = "1.0.6"

--- a/migration-engine/macros/src/lib.rs
+++ b/migration-engine/macros/src/lib.rs
@@ -1,0 +1,63 @@
+extern crate proc_macro;
+
+use darling::FromMeta;
+use proc_macro::TokenStream;
+use proc_macro2::Span;
+use quote::quote;
+use syn::{parse_macro_input, AttributeArgs, Ident, ItemFn};
+
+#[derive(Debug, FromMeta)]
+struct TestOneConnectorArgs {
+    /// The name of the connector to test.
+    #[darling(default)]
+    connector: String,
+}
+
+const CONNECTOR_NAMES: &[&'static str] = &["postgres", "mysql", "sqlite"];
+
+#[derive(Debug, FromMeta)]
+struct TestEachConnectorArgs {
+    /// Comma-separated list of connectors to exclude.
+    #[darling(default)]
+    ignore: Option<String>,
+}
+
+#[proc_macro_attribute]
+pub fn test_each_connector(attr: TokenStream, input: TokenStream) -> TokenStream {
+    let attributes_meta: syn::AttributeArgs = parse_macro_input!(attr as AttributeArgs);
+    let args = TestEachConnectorArgs::from_list(&attributes_meta);
+
+    match args {
+        Ok(_) => (),
+        Err(err) => panic!("{}", err),
+    };
+
+    let test_function = parse_macro_input!(input as ItemFn);
+    let test_fn_name = &test_function.sig.ident;
+
+    let mut tests = Vec::new();
+
+    for connector in CONNECTOR_NAMES {
+        let connector_test_fn_name = Ident::new(&format!("{}_on_{}", test_fn_name, connector), Span::call_site());
+        let connector_api_factory = Ident::new(&format!("{}_test_api", connector), Span::call_site());
+
+        let test = quote! {
+            #[test]
+            fn #connector_test_fn_name() {
+                let api = #connector_api_factory();
+
+                #test_fn_name(&api)
+            }
+        };
+
+        tests.push(test);
+    }
+
+    let output = quote! {
+        #(#tests)*
+
+        #test_function
+    };
+
+    output.into()
+}


### PR DESCRIPTION
## Rationale

- We can better isolate the tests. With the test_each_connector
function, each test runs on all connectors. With this macro, you can
target a specific connector, for example
`./test.sh single_watch_migration_must_work_on_sqlite`.

- Test setup is hidden from the tests, allowing us to refactor it more
easily in the future.

- More specifically, it should make it easier for us to migrate our
tests to async/await because the test function can be an `async fn`.

- We cut one level of indentation.

This commit also defines an opaque `TestApi` struct to make the test
setup a single argument and opaque to the test functions.

## What the macro expands to

When you write this:

```rust
#[test_each_connector]
fn migration_works(api: &TestApi) {
    /* contents of the test */
}
```

The macro expands to:

```rust
#[test]
fn migration_works_on_postgres() {
    let api = postgres_api();
    migration_works(&api)
}

// ... same thing for mysql and sqlite ...

fn migration_works(api: &TestApi) {
    /* contents of the test */
}
```