### PR TITLE
[migration-engine] Convert one migration test to test_each_connector with ignore

### DIFF
--- a/migration-engine/core/tests/migration_tests.rs
+++ b/migration-engine/core/tests/migration_tests.rs
@@ -1300,29 +1300,27 @@ fn adding_a_scalar_list_for_a_modelwith_id_type_int_must_work() {
     });
 }
 
-#[test]
-fn updating_a_model_with_a_scalar_list_to_a_different_id_type_must_work() {
-    test_each_connector_with_ignores(vec![SqlFamily::Mysql], |test_setup, api| {
-        let dm = r#"
-            model A {
-                id Int @id
-                strings String[]
-            }
-        "#;
-        let result = infer_and_apply(test_setup, api, &dm).sql_schema;
-        let node_id_column = result.table_bang("A_strings").column_bang("nodeId");
-        assert_eq!(node_id_column.tpe.family, ColumnTypeFamily::Int);
+#[test_each_connector(ignore = "mysql")]
+fn updating_a_model_with_a_scalar_list_to_a_different_id_type_must_work(api: &TestApi) {
+    let dm = r#"
+        model A {
+            id Int @id
+            strings String[]
+        }
+    "#;
+    let result = api.infer_and_apply(&dm).sql_schema;
+    let node_id_column = result.table_bang("A_strings").column_bang("nodeId");
+    assert_eq!(node_id_column.tpe.family, ColumnTypeFamily::Int);
 
-        let dm = r#"
-            model A {
-                id String @id @default(cuid())
-                strings String[]
-            }
-        "#;
-        let result = infer_and_apply(test_setup, api, &dm).sql_schema;
-        let node_id_column = result.table_bang("A_strings").column_bang("nodeId");
-        assert_eq!(node_id_column.tpe.family, ColumnTypeFamily::String);
-    });
+    let dm = r#"
+        model A {
+            id String @id @default(cuid())
+            strings String[]
+        }
+    "#;
+    let result = api.infer_and_apply(&dm).sql_schema;
+    let node_id_column = result.table_bang("A_strings").column_bang("nodeId");
+    assert_eq!(node_id_column.tpe.family, ColumnTypeFamily::String);
 }
 
 #[test]


### PR DESCRIPTION
Minor test setup improvement.