### PR TITLE
Only start a transaction if needed

### DIFF
--- a/query-engine/connectors/sql-query-connector/src/database/operations/write.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/write.rs
@@ -2,7 +2,6 @@ use crate::{error::SqlError, query_builder::WriteQueryBuilder, QueryExt};
 use connector_interface::{error::ConnectorError, *};
 use prisma_models::*;
 use quaint::error::Error as QueryError;
-use std::sync::Arc;
 
 pub async fn create_record(
     conn: &dyn QueryExt,

--- a/query-engine/connectors/sql-query-connector/src/query_builder/read/many_related_records/base_query.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/read/many_related_records/base_query.rs
@@ -2,7 +2,6 @@ use crate::{cursor_condition::CursorCondition, filter_conversion::AliasedConditi
 use connector_interface::{QueryArguments, SkipAndLimit};
 use prisma_models::prelude::*;
 use quaint::ast::{Aliasable, Comparable, ConditionTree, Joinable, Select};
-use std::sync::Arc;
 
 pub struct ManyRelatedRecordsBaseQuery<'a> {
     pub from_field: &'a RelationFieldRef,

--- a/query-engine/connectors/sql-query-connector/src/query_ext.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_ext.rs
@@ -10,7 +10,7 @@ use quaint::{
     connector::{self, Queryable},
 };
 use serde_json::{Map, Number, Value};
-use std::{convert::TryFrom, sync::Arc};
+use std::convert::TryFrom;
 
 impl<'t> QueryExt for connector::Transaction<'t> {}
 

--- a/query-engine/core/src/query_graph/mod.rs
+++ b/query-engine/core/src/query_graph/mod.rs
@@ -132,6 +132,10 @@ pub struct QueryGraph {
     marked_node_pairs: Vec<(NodeRef, NodeRef)>,
 
     finalized: bool,
+
+    /// For now a stupid marker if the query graph needs to be run inside a
+    /// transaction. Should happen if any of the queries is writing data.
+    needs_transaction: bool,
 }
 
 /// Implementation detail of the QueryGraph.
@@ -229,6 +233,16 @@ impl QueryGraph {
         let edge = EdgeRef { edge_ix };
 
         after_edge_creation(self, &edge).map(|_| edge)
+    }
+
+    /// Mark the query graph to need a transaction.
+    pub fn flag_transactional(&mut self) {
+        self.needs_transaction = true;
+    }
+
+    /// If true, the graph should be executed inside of a transaction.
+    pub fn needs_transaction(&self) -> bool {
+        self.needs_transaction
     }
 
     /// Returns a reference to the content of `node`, if the content is still present.

--- a/query-engine/core/src/query_graph_builder/builder.rs
+++ b/query-engine/core/src/query_graph_builder/builder.rs
@@ -38,7 +38,11 @@ impl QueryGraphBuilder {
     /// Maps a write operation to one or more queries.
     fn map_write_operation(&self, write_selection: Selection) -> QueryGraphBuilderResult<(QueryGraph, IrSerializer)> {
         let mutation_object = self.query_schema.mutation();
-        Self::process(write_selection, &mutation_object)
+
+        let (mut graph, ir_ser) = Self::process(write_selection, &mutation_object)?;
+        graph.flag_transactional();
+
+        Ok((graph, ir_ser))
     }
 
     fn process(


### PR DESCRIPTION
This should fix a regression with the new query graph that spawns transactions even if we don't need  one. The fix is kind of stupid but simple, we mark the graph to be transactional if we spot even one write query.

![tx-vs-no-tx](https://user-images.githubusercontent.com/34967/68119089-a3354580-fef9-11e9-8e5f-2b3c03ccd0bc.png)

The smaller bars are from this PR, the taller ones from master