### PR TITLE
[migration engine] Add a destructive change check for ALTER COLUMN

### DIFF
--- a/migration-engine/core/tests/existing_data_tests.rs
+++ b/migration-engine/core/tests/existing_data_tests.rs
@@ -1,14 +1,13 @@
 mod test_harness;
+
 use migration_connector::MigrationWarning;
 use pretty_assertions::assert_eq;
 use quaint::ast::*;
-use sql_migration_connector::SqlFamily;
 use test_harness::*;
 
-#[test]
-fn adding_a_required_field_if_there_is_data() {
-    test_each_connector(|test_setup, api| {
-        let dm = r#"
+#[test_each_connector]
+fn adding_a_required_field_if_there_is_data(api: &TestApi) {
+    let dm = r#"
             model Test {
                 id String @id @default(cuid())
             }
@@ -18,12 +17,12 @@ fn adding_a_required_field_if_there_is_data() {
                 A
             }
         "#;
-        infer_and_apply(test_setup, api, &dm).sql_schema;
+    api.infer_and_apply(&dm).sql_schema;
 
-        let insert = Insert::single_into((SCHEMA_NAME, "Test")).value("id", "test");
-        test_setup.database.execute(insert.into()).unwrap();
+    let insert = Insert::single_into((SCHEMA_NAME, "Test")).value("id", "test");
+    api.database().execute(insert.into()).unwrap();
 
-        let dm = r#"
+    let dm = r#"
             model Test {
                 id String @id @default(cuid())
                 myint Int
@@ -39,14 +38,12 @@ fn adding_a_required_field_if_there_is_data() {
                 A
             }
         "#;
-        infer_and_apply(test_setup, api, &dm);
-    });
+    api.infer_and_apply(&dm);
 }
 
-#[test]
-fn adding_a_required_field_must_use_the_default_value_for_migrations() {
-    test_each_connector(|test_setup, api| {
-        let dm = r#"
+#[test_each_connector]
+fn adding_a_required_field_must_use_the_default_value_for_migrations(api: &TestApi) {
+    let dm = r#"
             model Test {
                 id String @id @default(cuid())
             }
@@ -56,14 +53,14 @@ fn adding_a_required_field_must_use_the_default_value_for_migrations() {
                 A
             }
         "#;
-        infer_and_apply(test_setup, api, &dm);
+    api.infer_and_apply(&dm);
 
-        let conn = &test_setup.database;
-        let insert = Insert::single_into((SCHEMA_NAME, "Test")).value("id", "test");
+    let conn = api.database();
+    let insert = Insert::single_into((SCHEMA_NAME, "Test")).value("id", "test");
 
-        conn.execute(insert.into()).unwrap();
+    conn.execute(insert.into()).unwrap();
 
-        let dm = r#"
+    let dm = r#"
             model Test {
                 id String @id @default(cuid())
                 myint Int @default(1)
@@ -82,101 +79,90 @@ fn adding_a_required_field_must_use_the_default_value_for_migrations() {
                 C
             }
         "#;
-        infer_and_apply(test_setup, api, &dm);
+    api.infer_and_apply(&dm);
 
-        // TODO: those assertions somehow fail with column not found on SQLite. I could observe the correct data in the db file though.
-        if test_setup.sql_family != SqlFamily::Sqlite {
-            let conditions = "id".equals("test");
-            let table_for_select: Table = match test_setup.sql_family {
-                SqlFamily::Sqlite => {
-                    // sqlite case. Otherwise quaint produces invalid SQL
-                    "Test".into()
-                }
-                _ => (SCHEMA_NAME, "Test").into(),
-            };
-            let query = Select::from_table(table_for_select).so_that(conditions);
-            let result_set = conn.query(query.into()).unwrap();
-            let row = result_set.into_iter().next().expect("query returned no results");
-            assert_eq!(row["myint"].as_i64().unwrap(), 1);
-            assert_eq!(row["string"].as_str().unwrap(), "test_string");
+    // TODO: those assertions somehow fail with column not found on SQLite. I could observe the correct data in the db file though.
+    if !api.is_sqlite() {
+        let conditions = "id".equals("test");
+        let table_for_select: Table = (SCHEMA_NAME, "Test").into();
+        let query = Select::from_table(table_for_select).so_that(conditions);
+        let result_set = conn.query(query.into()).unwrap();
+        let row = result_set.into_iter().next().expect("query returned no results");
+        assert_eq!(row["myint"].as_i64().unwrap(), 1);
+        assert_eq!(row["string"].as_str().unwrap(), "test_string");
+    }
+}
+
+#[test_each_connector]
+fn dropping_a_table_with_rows_should_warn(api: &TestApi) {
+    let dm = r#"
+        model Test {
+            id String @id @default(cuid())
         }
-    });
+    "#;
+    let original_database_schema = api.infer_and_apply(&dm).sql_schema;
+
+    let conn = api.database();
+    let insert = Insert::single_into((SCHEMA_NAME, "Test")).value("id", "test");
+
+    conn.execute(insert.into()).unwrap();
+
+    let dm = "";
+
+    let InferAndApplyOutput {
+        migration_output,
+        sql_schema: final_database_schema,
+    } = api.infer_and_apply(&dm);
+
+    // The schema should not change because the migration should not run if there are warnings
+    // and the force flag isn't passed.
+    assert_eq!(original_database_schema, final_database_schema);
+
+    assert_eq!(
+        migration_output.warnings,
+        &[MigrationWarning {
+            description: "You are about to drop the table `Test`, which is not empty (1 rows).".into()
+        }]
+    );
 }
 
-#[test]
-fn dropping_a_table_with_rows_should_warn() {
-    test_each_connector(|test_setup, engine| {
-        let dm = r#"
-                    model Test {
-                        id String @id @default(cuid())
-                    }
-                "#;
-        let original_database_schema = infer_and_apply(test_setup, engine, &dm).sql_schema;
-
-        let conn = &test_setup.database;
-        let insert = Insert::single_into((SCHEMA_NAME, "Test")).value("id", "test");
-
-        conn.execute(insert.into()).unwrap();
-
-        let dm = "";
-
-        let InferAndApplyOutput {
-            migration_output,
-            sql_schema: final_database_schema,
-        } = infer_and_apply(test_setup, engine, &dm);
-
-        // The schema should not change because the migration should not run if there are warnings
-        // and the force flag isn't passed.
-        assert_eq!(original_database_schema, final_database_schema);
-
-        assert_eq!(
-            migration_output.warnings,
-            &[MigrationWarning {
-                description: "You are about to drop the table `Test`, which is not empty (1 rows).".into()
-            }]
-        );
-    })
-}
-
-#[test]
-fn dropping_a_column_with_non_null_values_should_warn() {
-    test_each_connector(|test_setup, engine| {
-        let dm = r#"
+#[test_each_connector]
+fn dropping_a_column_with_non_null_values_should_warn(api: &TestApi) {
+    let dm = r#"
             model Test {
                 id String @id @default(cuid())
                 puppiesCount Int?
             }
         "#;
 
-        let original_database_schema = infer_and_apply(test_setup, engine, &dm).sql_schema;
+    let original_database_schema = api.infer_and_apply(&dm).sql_schema;
 
-        let insert = Insert::multi_into((SCHEMA_NAME, "Test"), vec!["id", "puppiesCount"])
-            .values(("a", 7))
-            .values(("b", 8));
+    let insert = Insert::multi_into((SCHEMA_NAME, "Test"), vec!["id", "puppiesCount"])
+        .values(("a", 7))
+        .values(("b", 8));
 
-        test_setup.database.execute(insert.into()).unwrap();
+    api.database().execute(insert.into()).unwrap();
 
-        // Drop the `favouriteAnimal` column.
-        let dm = r#"
+    // Drop the `favouriteAnimal` column.
+    let dm = r#"
             model Test {
                 id String @id @default(cuid())
             }
         "#;
 
-        let InferAndApplyOutput {
-            migration_output,
-            sql_schema: final_database_schema,
-        } = infer_and_apply(test_setup, engine, &dm);
+    let InferAndApplyOutput {
+        migration_output,
+        sql_schema: final_database_schema,
+    } = api.infer_and_apply(&dm);
 
-        // The schema should not change because the migration should not run if there are warnings
-        // and the force flag isn't passed.
-        assert_eq!(original_database_schema, final_database_schema);
+    // The schema should not change because the migration should not run if there are warnings
+    // and the force flag isn't passed.
+    assert_eq!(original_database_schema, final_database_schema);
 
-        assert_eq!(
+    assert_eq!(
             migration_output.warnings,
             &[MigrationWarning {
                 description: "You are about to drop the column `puppiesCount` on the `Test` table, which still contains 2 non-null values.".to_owned(),
             }]
         );
-    });
 }

--- a/migration-engine/core/tests/test_harness/test_api.rs
+++ b/migration-engine/core/tests/test_harness/test_api.rs
@@ -25,6 +25,14 @@ pub struct TestApi {
 }
 
 impl TestApi {
+    pub fn database(&self) -> &Arc<dyn SyncSqlConnection + Send + Sync + 'static> {
+        &self.database
+    }
+
+    pub fn is_sqlite(&self) -> bool {
+        self.sql_family == SqlFamily::Sqlite
+    }
+
     pub fn migration_persistence(&self) -> Arc<dyn MigrationPersistence> {
         self.api.migration_persistence()
     }


### PR DESCRIPTION
This is meant to make the data loss explicit until we figure out which field can be made non-destructive.

closes https://github.com/prisma/prisma-engine/issues/156

Relevant specs issue: https://github.com/prisma/specs/issues/275

I suggest reviewing the 2 commits separately.
