### PR TITLE
Factor out migration_core::CliError::exit_code

### DIFF
--- a/migration-engine/core/src/cli.rs
+++ b/migration-engine/core/src/cli.rs
@@ -30,6 +30,20 @@ pub enum CliError {
     Other(String),
 }
 
+impl CliError {
+    pub(crate) fn exit_code(&self) -> i32 {
+        match self {
+            CliError::DatabaseDoesNotExist(_) => 1,
+            CliError::DatabaseAccessDenied(_) => 2,
+            CliError::AuthenticationFailed(_) => 3,
+            CliError::ConnectTimeout | CliError::Timeout => 4,
+            CliError::DatabaseAlreadyExists(_) => 5,
+            CliError::TlsError(_) => 6,
+            _ => 255,
+        }
+    }
+}
+
 impl From<ConnectorError> for CliError {
     fn from(e: ConnectorError) -> Self {
         match e {

--- a/migration-engine/core/src/main.rs
+++ b/migration-engine/core/src/main.rs
@@ -111,29 +111,7 @@ fn main() {
             Err(error) => {
                 error!("{}", error);
 
-                match error {
-                    CliError::DatabaseDoesNotExist(_) => {
-                        std::process::exit(1);
-                    }
-                    CliError::DatabaseAccessDenied(_) => {
-                        std::process::exit(2);
-                    }
-                    CliError::AuthenticationFailed(_) => {
-                        std::process::exit(3);
-                    }
-                    CliError::ConnectTimeout | CliError::Timeout => {
-                        std::process::exit(4);
-                    }
-                    CliError::DatabaseAlreadyExists(_) => {
-                        std::process::exit(5);
-                    }
-                    CliError::TlsError(_) => {
-                        std::process::exit(6);
-                    }
-                    _ => {
-                        std::process::exit(255);
-                    }
-                }
+                std::process::exit(error.exit_code());
             }
         }
     } else {


### PR DESCRIPTION
To keep main.rs small.