### PR TITLE
Add ConnectionInfo::from_datasource

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2141,7 +2141,7 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.1.0"
-source = "git+https://github.com/prisma/quaint.git#0401051a38c0f5d6b7ad1d7d9049d36e24779a95"
+source = "git+https://github.com/prisma/quaint.git#ab10f2d7ad6ec326bc2e4f7bc5e7d1ebfb073d51"
 dependencies = [
  "async-std 0.99.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3447,7 +3447,7 @@ name = "twox-hash"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/libs/sql-connection/src/connection_info.rs
+++ b/libs/sql-connection/src/connection_info.rs
@@ -21,7 +21,7 @@ pub enum ConnectionInfo {
     /// A SQLite connection URL.
     Sqlite {
         /// The filesystem path of the SQLite database.
-        file_path: PathBuf,
+        file_path: String,
         /// The name the database is bound to (with `ATTACH DATABASE`), if available.
         db_name: Option<String>,
     },
@@ -52,7 +52,7 @@ impl ConnectionInfo {
         if url_result.is_err() {
             let params = SqliteParams::try_from(url_str)?;
             return Ok(ConnectionInfo::Sqlite {
-                file_path: params.file_path.to_string_lossy().into_owned(),
+                file_path: params.file_path,
                 db_name: None,
             });
         }
@@ -68,7 +68,7 @@ impl ConnectionInfo {
             SqlFamily::Sqlite => {
                 let params = SqliteParams::try_from(url_str)?;
                 Ok(ConnectionInfo::Sqlite {
-                    file_path: params.file_path.to_string_lossy().into_owned(),
+                    file_path: params.file_path,
                     db_name: None,
                 })
             }

--- a/libs/sql-connection/src/sqlite.rs
+++ b/libs/sql-connection/src/sqlite.rs
@@ -27,14 +27,14 @@ impl Sqlite {
     /// - `db_name` is the name the database will be attached to for all the connections in the pool.
     pub fn new(url: &str, db_name: &str) -> Result<Self, QueryError> {
         let params = SqliteParams::try_from(url)?;
-        let file_path = params.file_path.to_str().unwrap().to_string();
+        let file_path = params.file_path;
 
         let pool = quaint::pool::sqlite(url, db_name)?;
 
         Ok(Self {
             pool,
             db_name: db_name.to_owned(),
-            file_path,
+            file_path: file_path.to_owned(),
             runtime: super::default_runtime(),
         })
     }

--- a/query-engine/connectors/sql-query-connector/src/database/sqlite.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/sqlite.rs
@@ -25,8 +25,8 @@ impl Sqlite {
 impl FromSource for Sqlite {
     fn from_source(source: &dyn Source) -> crate::Result<Self> {
         let params = SqliteParams::try_from(source.url().value.as_str())?;
-        let db_name = params.file_path.file_stem().unwrap().to_str().unwrap().to_owned();
-        let file_path = params.file_path.to_str().unwrap().to_string();
+        let db_name = std::path::Path::new(&params.file_path).file_stem().unwrap().to_str().unwrap().to_owned();
+        let file_path = params.file_path;
         let pool = pool::sqlite(&file_path, &db_name)?;
 
         Ok(Self { pool, file_path })


### PR DESCRIPTION
It's more robust than figuring out which database we have from the database URL.

Additionally, use new quaint version with a small improvement for SQLite file paths.