### PR TITLE
Use SegQueue instead of Mutex<String> for interpreter logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2097,6 +2097,7 @@ dependencies = [
  "async-std 0.99.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-trait 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-queue 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "debug_stub_derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/query-engine/core/Cargo.toml
+++ b/query-engine/core/Cargo.toml
@@ -24,3 +24,4 @@ im = "13.0"
 futures = "0.3"
 async-std = { version = "0.99", features = ["unstable"] }
 async-trait = "0.1"
+crossbeam-queue = "0.2"

--- a/query-engine/core/src/executor/pipeline.rs
+++ b/query-engine/core/src/executor/pipeline.rs
@@ -24,7 +24,7 @@ impl<'conn, 'tx> QueryPipeline<'conn, 'tx> {
         let expr = Expressionista::translate(self.graph)?;
         let result = self.interpreter.interpret(expr, Env::default(), 0).await;
 
-        trace!("{}", self.interpreter.log.lock().await);
+        trace!("{}", self.interpreter.log_output());
         Ok(serializer.serialize(result?))
     }
 }


### PR DESCRIPTION
This one at least allocates a bit less than before and does not protect the log with a `Mutex` when we really don't need one.

What I want to see here additionally is to not log at all if log level is not `TRACE`.