### PR TITLE
Performance fix for related select

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2046,7 +2046,7 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.1.0"
-source = "git+https://github.com/prisma/quaint.git#9f6e1b5b5ed10aaca9a16d74c94a20b400275064"
+source = "git+https://github.com/prisma/quaint.git#4e9084f51520e2365fcc3681287a166bc6d347aa"
 dependencies = [
  "async-std 0.99.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/libs/prisma-models/src/field/relation.rs
+++ b/libs/prisma-models/src/field/relation.rs
@@ -119,7 +119,6 @@ impl RelationField {
             Some(RelationLinkManifestation::Inline(ref m)) => {
                 let is_self_rel = relation.is_self_relation();
 
-
                 if is_self_rel && self.is_hidden {
                     false
                 } else if is_self_rel && (self.relation_side == RelationSide::B || self.related_field().is_hidden) {

--- a/libs/prisma-models/src/sql_ext/selected_fields.rs
+++ b/libs/prisma-models/src/sql_ext/selected_fields.rs
@@ -7,7 +7,11 @@ pub trait SelectedFieldsExt {
 
 impl SelectedFieldsExt for SelectedFields {
     fn columns(&self) -> Vec<Column<'static>> {
-        let mut result: Vec<Column<'static>> = self.scalar_non_list().iter().map(|f| f.as_column()).collect();
+        let mut result: Vec<Column<'static>> = self
+            .scalar_non_list()
+            .iter()
+            .map(|f| f.as_column())
+            .collect();
 
         for rf in self.relation_inlined().iter() {
             result.push(rf.as_column());
@@ -16,19 +20,33 @@ impl SelectedFieldsExt for SelectedFields {
         if let Some(ref from_field) = self.from_field {
             let relation = from_field.relation();
 
-            result.push(
-                relation
-                    .column_for_relation_side(from_field.relation_side.opposite())
-                    .alias(SelectedFields::RELATED_MODEL_ALIAS)
-                    .table(Relation::TABLE_ALIAS),
-            );
+            if from_field.relation_is_inlined_in_child() {
+                result.push(
+                    relation
+                        .column_for_relation_side(from_field.relation_side.opposite())
+                        .alias(SelectedFields::RELATED_MODEL_ALIAS)
+                );
 
-            result.push(
-                relation
-                    .column_for_relation_side(from_field.relation_side)
-                    .alias(SelectedFields::PARENT_MODEL_ALIAS)
-                    .table(Relation::TABLE_ALIAS),
-            );
+                result.push(
+                    relation
+                        .column_for_relation_side(from_field.relation_side)
+                        .alias(SelectedFields::PARENT_MODEL_ALIAS),
+                );
+            } else {
+                result.push(
+                    relation
+                        .column_for_relation_side(from_field.relation_side.opposite())
+                        .alias(SelectedFields::RELATED_MODEL_ALIAS)
+                        .table(Relation::TABLE_ALIAS),
+                );
+
+                result.push(
+                    relation
+                        .column_for_relation_side(from_field.relation_side)
+                        .alias(SelectedFields::PARENT_MODEL_ALIAS)
+                        .table(Relation::TABLE_ALIAS),
+                );
+            }
         };
 
         result

--- a/query-engine/connectors/sql-query-connector/src/database/operations/read.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/read.rs
@@ -6,6 +6,7 @@ use connector_interface::{error::ConnectorError, *};
 use itertools::Itertools;
 use prisma_models::*;
 use std::convert::TryFrom;
+use quaint::ast::*;
 
 struct ScalarListElement {
     record_id: GraphqlId,
@@ -67,7 +68,17 @@ where
     let idents = selected_fields.type_identifiers();
     let field_names = selected_fields.names();
 
-    let query = {
+    let can_skip_joins =
+        from_field.relation_is_inlined_in_child() && !query_arguments.is_with_pagination();
+
+    let query = if can_skip_joins {
+        let model = from_field.related_model();
+
+        let select = read::get_records(&model, selected_fields, query_arguments)
+            .and_where(from_field.relation_column().in_selection(from_record_ids.to_owned()));
+
+        Query::from(select)
+    } else {
         let is_with_pagination = query_arguments.is_with_pagination();
         let base = ManyRelatedRecordsBaseQuery::new(from_field, from_record_ids, query_arguments, selected_fields);
 


### PR DESCRIPTION
If the relation column is in the same table, do not join with itself.

We can only do this if the query has no pagination, in the optimal case we can cut a big slice of the response time off.

Query:

``` graphql
query {
  findManyUser(where: { firstName: "Face" })
  {
    firstName
    lastName
    posts { id }
  }
}
```
Schema:
``` prisma
model User {
  id         Int       @id @unique
  firstName  String
  lastName   String
  age        Int?
  email      String?
  password   String?
  posts      Post[]
  comments   Comment[]
  likes      Like[]
  friendWith User[]    @relation("FriendShip")
  friendOf   User[]    @relation("FriendShip")
  createdAt  DateTime  @default(now())
  updatedAt  DateTime  @updatedAt
}

model Post {
  id        Int       @id @unique
  content   String?
  author    User
  comments  Comment[]
  likes     Like[]
  createdAt DateTime  @default(now())
  updatedAt DateTime  @updatedAt

  @@index([author])
}

model Comment {
  id        Int       @id @unique
  content   String?
  author    User
  post      Post
  likes     Like[]
  createdAt DateTime  @default(now())
  updatedAt DateTime  @updatedAt

  @@index([author])
  @@index([post])
}

model Like {
  id        Int       @id @unique
  user      User
  post      Post
  comment   Comment
  createdAt DateTime  @default(now())
  updatedAt DateTime  @updatedAt

  @@index([user])
  @@index([post])
  @@index([comment])
}
```

Data generated to psql 10 with [sql-load-test](https://github.com/prisma/sql-load-test) with 3 000 000 users, 30 000 000 posts, 30 000 000 comments and 150 000 000 likes.

Green: master, purple: this PR, database psql, y-axis nanoseconds, x-axis requests per second:

![self_join](https://user-images.githubusercontent.com/34967/69255815-5f586680-0bb0-11ea-92bc-921cdf2dd454.png)

Fixes https://github.com/prisma/prisma-engine/issues/127
