### PR TITLE
Relax Data Model Validator

### DIFF
--- a/introspection-engine/core/src/tests/error_tests.rs
+++ b/introspection-engine/core/src/tests/error_tests.rs
@@ -10,7 +10,7 @@ async fn unreachable_database_must_return_a_proper_error_on_mysql() {
 
     url.set_port(Some(8787)).unwrap();
 
-    let error = RpcImpl::introspect_internal(url.clone().into_string())
+    let error = RpcImpl::introspect_internal(url.as_str())
         .await
         .unwrap_err();
 

--- a/libs/datamodel/core/src/validator/validate.rs
+++ b/libs/datamodel/core/src/validator/validate.rs
@@ -92,7 +92,7 @@ impl Validator {
 
             if !is_valid {
                 return Err(DatamodelError::new_model_validation_error(
-                    "Invalid ID field. ID field must be one of: Int @id, String @id @default(cuid()), String @id @default(uuid()).",
+                    "Invalid ID field. ID field must be one of: Int @id, String @id, String @id @default(cuid()), String @id @default(uuid()).",
                     &model.name,
                     ast_schema.find_field(&model.name, &id_field.name).expect(STATE_ERROR).span));
             }

--- a/libs/datamodel/core/src/validator/validate.rs
+++ b/libs/datamodel/core/src/validator/validate.rs
@@ -86,6 +86,7 @@ impl Validator {
                     name_eq && type_eq && args_eq
                 }
                 (None, dml::FieldType::Base(dml::ScalarType::Int), dml::FieldArity::Required) => true,
+                (None, dml::FieldType::Base(dml::ScalarType::String), dml::FieldArity::Required) => true,
                 _ => false,
             };
 

--- a/libs/datamodel/core/tests/directives/id_negative.rs
+++ b/libs/datamodel/core/tests/directives/id_negative.rs
@@ -114,7 +114,7 @@ fn it_must_error_when_multi_field_is_referring_to_undefined_fields() {
 }
 
 const ID_TYPE_ERROR: &str =
-    "Invalid ID field. ID field must be one of: Int @id, String @id @default(cuid()), String @id @default(uuid()).";
+    "Invalid ID field. ID field must be one of: Int @id, String @id, String @id @default(cuid()), String @id @default(uuid()).";
 
 #[test]
 fn id_should_error_if_the_id_field_is_not_of_valid_type() {
@@ -176,19 +176,15 @@ fn id_should_error_if_string_id_field_has_incorrect_default_value() {
     "#;
 
     let errors = parse_error(dml);
-
-    //    errors.assert_is_at(
-    //        0,
-    //        DatamodelError::new_model_validation_error(ID_TYPE_ERROR, "Model1", Span::new(28, 41)),
-    //    );
+    dbg!(&errors);
 
     errors.assert_is_at(
-        1,
+        0,
         DatamodelError::new_model_validation_error(ID_TYPE_ERROR, "Model2", Span::new(76, 107)),
     );
 
     errors.assert_is_at(
-        2,
+        1,
         DatamodelError::new_model_validation_error(ID_TYPE_ERROR, "Model3", Span::new(142, 172)),
     );
 }

--- a/libs/datamodel/core/tests/directives/id_negative.rs
+++ b/libs/datamodel/core/tests/directives/id_negative.rs
@@ -177,10 +177,10 @@ fn id_should_error_if_string_id_field_has_incorrect_default_value() {
 
     let errors = parse_error(dml);
 
-    errors.assert_is_at(
-        0,
-        DatamodelError::new_model_validation_error(ID_TYPE_ERROR, "Model1", Span::new(28, 41)),
-    );
+    //    errors.assert_is_at(
+    //        0,
+    //        DatamodelError::new_model_validation_error(ID_TYPE_ERROR, "Model1", Span::new(28, 41)),
+    //    );
 
     errors.assert_is_at(
         1,

--- a/libs/datamodel/core/tests/directives/id_positive.rs
+++ b/libs/datamodel/core/tests/directives/id_positive.rs
@@ -117,6 +117,39 @@ fn should_allow_string_ids_with_uuid() {
 }
 
 #[test]
+fn should_allow_string_ids_without_default() {
+    let dml = r#"
+    model Model {
+        id String @id
+    }
+    "#;
+
+    let datamodel = parse(dml);
+    let user_model = datamodel.assert_has_model("Model");
+    user_model
+        .assert_has_field("id")
+        .assert_is_id(true)
+        .assert_base_type(&ScalarType::String);
+}
+
+#[test]
+fn should_allow_string_ids_without_default_with_strategy_none() {
+    let dml = r#"
+    model Model {
+        id String @id(strategy: NONE)
+    }
+    "#;
+
+    let datamodel = parse(dml);
+    let user_model = datamodel.assert_has_model("Model");
+    user_model
+        .assert_has_field("id")
+        .assert_is_id(true)
+        .assert_base_type(&ScalarType::String)
+        .assert_id_strategy(IdStrategy::None);
+}
+
+#[test]
 fn multi_field_ids_must_work() {
     let dml = r#"
     model Model {


### PR DESCRIPTION
The parser should now allow `id_field: String @id` as valid. 