### PR TITLE
Add timeout to introspection and migration engine connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -986,6 +986,9 @@ dependencies = [
  "sql-introspection-connector 0.1.0",
  "test-setup 0.1.0",
  "tokio 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-futures 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-subscriber 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "user-facing-errors 0.1.0",
 ]
@@ -2492,6 +2495,8 @@ dependencies = [
  "test-macros 0.1.0",
  "test-setup 0.1.0",
  "tokio 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-futures 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "user-facing-errors 0.1.0",
 ]
@@ -2513,6 +2518,7 @@ dependencies = [
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "sql-schema-describer 0.1.0",
+ "tokio 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing-futures 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "user-facing-errors 0.1.0",

--- a/introspection-engine/connectors/sql-introspection-connector/Cargo.toml
+++ b/introspection-engine/connectors/sql-introspection-connector/Cargo.toml
@@ -17,6 +17,9 @@ log = "0.4"
 regex = "1.2"
 url = "1.7"
 user-facing-errors = { path = "../../../libs/user-facing-errors" }
+tracing = "0.1.10"
+tracing-futures = "0.2.0"
+tokio = { version = "0.2", features = ["rt-threaded", "time"] }
 
 [dependencies.quaint]
 git = "https://github.com/prisma/quaint.git"
@@ -27,6 +30,5 @@ fern = "0.5"
 barrel = { version = "0.6.3-alpha.0", features = ["sqlite3", "mysql", "pg"] }
 test-macros = { path = "../../../libs/test-macros" }
 test-setup = { path = "../../../libs/test-setup" }
-tokio = { version = "0.2", features = ["rt-threaded"] }
 once_cell = "1.2.0"
 pretty_assertions = "0.6.1"

--- a/introspection-engine/core/Cargo.toml
+++ b/introspection-engine/core/Cargo.toml
@@ -23,6 +23,9 @@ datamodel = { path = "../../libs/datamodel/core" }
 user-facing-errors = { path = "../../libs/user-facing-errors" }
 introspection-connector = { path = "../connectors/introspection-connector" }
 sql-introspection-connector = { path = "../connectors/sql-introspection-connector" }
+tracing = "0.1.10"
+tracing-subscriber = "0.1.6"
+tracing-futures = "0.2.0"
 
 [dependencies.tokio]
 version = "0.2"

--- a/introspection-engine/core/src/main.rs
+++ b/introspection-engine/core/src/main.rs
@@ -11,6 +11,8 @@ use rpc::{Rpc, RpcImpl};
 
 fn main() {
     let matches = cli::clap_app().get_matches();
+    std::env::set_var("RUST_LOG", "debug");
+    init_logger();
 
     if matches.is_present("version") {
         println!(env!("GIT_HASH"));
@@ -26,4 +28,13 @@ fn main() {
         let server = ServerBuilder::new(io_handler);
         server.build();
     }
+}
+
+fn init_logger() {
+    use tracing_subscriber::{EnvFilter, FmtSubscriber};
+
+    FmtSubscriber::builder()
+        .with_env_filter(EnvFilter::from_default_env())
+        .with_writer(std::io::stderr)
+        .init()
 }

--- a/introspection-engine/core/src/rpc.rs
+++ b/introspection-engine/core/src/rpc.rs
@@ -6,6 +6,7 @@ use jsonrpc_derive::rpc;
 use serde_derive::*;
 use std::{future::Future as StdFuture, sync::Mutex};
 use tokio::runtime::Runtime;
+use tracing_futures::Instrument;
 
 #[rpc]
 pub trait Rpc {
@@ -33,7 +34,7 @@ impl Rpc for RpcImpl {
     }
 
     fn introspect(&self, url: UrlInput) -> Result<String> {
-        self.block_on(Self::introspect_internal(&url.url))
+        self.block_on(Self::introspect_internal(&url.url).instrument(tracing::info_span!("Introspect", ?url)))
     }
 }
 
@@ -70,7 +71,7 @@ impl RpcImpl {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct UrlInput {
     pub(crate) url: String,
 }

--- a/libs/user-facing-errors/src/quaint.rs
+++ b/libs/user-facing-errors/src/quaint.rs
@@ -111,6 +111,18 @@ pub fn render_quaint_error(quaint_error: &QuaintError, connection_info: &Connect
         })
         .ok(),
 
+        (QuaintError::ConnectTimeout, ConnectionInfo::Mysql(url)) => KnownError::new(common::DatabaseNotReachable {
+            database_host: url.host().to_owned(),
+            database_port: url.port(),
+        })
+        .ok(),
+
+        (QuaintError::ConnectTimeout, ConnectionInfo::Postgres(url)) => KnownError::new(common::DatabaseNotReachable {
+            database_host: url.host().to_owned(),
+            database_port: url.port(),
+        })
+        .ok(),
+
         _ => None,
     }
 }

--- a/migration-engine/connectors/sql-migration-connector/Cargo.toml
+++ b/migration-engine/connectors/sql-migration-connector/Cargo.toml
@@ -20,6 +20,7 @@ failure = "0.1"
 user-facing-errors = { path = "../../../libs/user-facing-errors" }
 tracing = "0.1.10"
 tracing-futures = "0.2.0"
+tokio = { version = "0.2", features = ["time"] }
 
 [dependencies.quaint]
 git = "https://github.com/prisma/quaint.git"

--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -24,8 +24,9 @@ use sql_database_step_applier::*;
 use sql_destructive_changes_checker::*;
 use sql_migration_persistence::*;
 use sql_schema_describer::SqlSchemaDescriberBackend;
-use std::{fs, path::PathBuf, sync::Arc};
+use std::{fs, path::PathBuf, sync::Arc, time::Duration};
 
+const CONNECTION_TIMEOUT: Duration = Duration::from_secs(10);
 pub type Result<T> = std::result::Result<T, SqlError>;
 
 pub struct SqlMigrationConnector {
@@ -44,22 +45,24 @@ impl SqlMigrationConnector {
         let connection_info =
             ConnectionInfo::from_url(database_str).map_err(|err| ConnectorError::url_parse_error(err, database_str))?;
 
-        let connection = Quaint::new(database_str)
-            .await
-            .map_err(SqlError::from)
-            .map_err(|err| err.into_connector_error(&connection_info))?;
+        let connection_fut = async {
+            let connection = Quaint::new(database_str)
+                .await
+                .map_err(SqlError::from)
+                .map_err(|err| err.into_connector_error(&connection_info))?;
 
-        Self::create_connector(connection).await
-    }
+            // async connections can be lazy, so we issue a simple query to fail early if the database
+            // is not reachable.
+            connection
+                .query_raw("SELECT 1", &[])
+                .await
+                .map_err(SqlError::from)
+                .map_err(|err| err.into_connector_error(&connection.connection_info()))?;
 
-    async fn create_connector(connection: Quaint) -> std::result::Result<Self, ConnectorError> {
-        // async connections can be lazy, so we issue a simple query to fail early if the database
-        // is not reachable.
-        connection
-            .query_raw("SELECT 1", &[])
-            .await
-            .map_err(SqlError::from)
-            .map_err(|err| err.into_connector_error(&connection.connection_info()))?;
+            Ok(connection)
+        };
+
+        let connection = tokio::time::timeout(CONNECTION_TIMEOUT, connection_fut).await.map_err(|_elapsed| SqlError::from(quaint::error::Error::ConnectTimeout).into_connector_error(&connection_info))??;
 
         let schema_name = connection.connection_info().schema_name().to_owned();
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -46,7 +46,8 @@ impl SqlDatabaseStepApplier {
 
         let step = &steps[index];
         let sql_string = render_raw_sql(&step, self.sql_family(), &self.schema_name);
-        debug!("{}", sql_string);
+
+        tracing::debug!(index, %sql_string);
 
         let result = self.conn.query_raw(&sql_string, &[]).await;
 

--- a/migration-engine/core/Cargo.toml
+++ b/migration-engine/core/Cargo.toml
@@ -24,7 +24,7 @@ failure = "0.1"
 jsonrpc-core = "13.0"
 jsonrpc-stdio-server = "13.0"
 
-futures = "0.3"
+futures = { version = "0.3", features = ["compat"] }
 tokio = { version = "0.2", features = ["rt-threaded", "macros"] }
 async-trait = "0.1.17"
 async-std = "1.0"


### PR DESCRIPTION
- Improve logging setup
- Transform connection timeouts into user facing errors

Fixes https://github.com/prisma/prisma2/issues/1056