### PR TITLE
Using the @@index notation in tests

### DIFF
--- a/query-engine/connector-test-kit/src/test/scala/queries/filters/nonEmbedded/ExtendedRelationFilterSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/filters/nonEmbedded/ExtendedRelationFilterSpec.scala
@@ -21,6 +21,7 @@ class ExtendedRelationFilterSpec extends FlatSpec with Matchers with ApiSpecBase
                                          |  Title   String
                                          |  Artist  Artist  @relation(references: [id])
                                          |  Tracks  Track[]
+                                         |  @@index([Artist])
                                          |}
                                          |
                                          |model Genre {
@@ -48,6 +49,9 @@ class ExtendedRelationFilterSpec extends FlatSpec with Matchers with ApiSpecBase
                                          |  Milliseconds Int
                                          |  Bytes        Int
                                          |  UnitPrice    Float
+                                         |  @@index([Album])
+                                         |  @@index([MediaType])
+                                         |  @@index([Genre])
                                          |}
                                          |""" }
 

--- a/query-engine/connector-test-kit/src/test/scala/queries/filters/nonEmbedded/ManyRelationFilterSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/filters/nonEmbedded/ManyRelationFilterSpec.scala
@@ -22,6 +22,7 @@ class ManyRelationFilterSpec extends FlatSpec with Matchers with ApiSpecBase {
       |   popularity Int
       |   blog       Blog   @relation(references: [id])
       |   comments   Comment[]
+      |   @@index([blog])
       |}
       |
       |model Comment {
@@ -29,6 +30,7 @@ class ManyRelationFilterSpec extends FlatSpec with Matchers with ApiSpecBase {
       |   text  String
       |   likes Int
       |   post  Post   @relation(references: [id])
+      |   @@index([post])
       |}
     """
   }

--- a/query-engine/connector-test-kit/src/test/scala/queries/filters/nonEmbedded/OneRelationFilterSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/filters/nonEmbedded/OneRelationFilterSpec.scala
@@ -21,6 +21,7 @@ class OneRelationFilterSpec extends FlatSpec with Matchers with ApiSpecBase {
       |   popularity Int
       |   blog       Blog?    @relation(references: [id])
       |   comment    Comment?
+      |   @@index([blog])
       |}
       |
       |model Comment {
@@ -28,6 +29,7 @@ class OneRelationFilterSpec extends FlatSpec with Matchers with ApiSpecBase {
       |   text  String
       |   likes Int
       |   post  Post?   @relation(references: [id])
+      |   @@index([post])
       |}
     """
   }


### PR DESCRIPTION
Let's add this to the tests so we see if some systems break when using it in the datamodel.

Both the migration engine and query engine have been broken before due to using `@@index` so I think it's a good idea to use it in the tests.