### PR TITLE
Print out full error span

### DIFF
--- a/libs/datamodel/core/src/ast/parser/mod.rs
+++ b/libs/datamodel/core/src/ast/parser/mod.rs
@@ -44,7 +44,7 @@ pub fn parse_expression(token: &pest::iterators::Pair<'_, Rule>) -> Expression {
         Rule::constant_literal => Expression::ConstantValue(current.as_str().to_string(), Span::from_pest(current.as_span())),
         Rule::function => parse_function(&current),
         Rule::array_expression => parse_array(&current),
-        _ => unreachable!("Encounterd impossible literal during parsing: {:?}", current.tokens())
+        _ => unreachable!("Encountered impossible literal during parsing: {:?}", current.tokens())
     };
 }
 
@@ -55,12 +55,12 @@ fn parse_function(token: &pest::iterators::Pair<'_, Rule>) -> Expression {
     match_children! { token, current,
         Rule::identifier => name = Some(current.as_str().to_string()),
         Rule::argument_value => arguments.push(parse_arg_value(&current)),
-        _ => unreachable!("Encounterd impossible function during parsing: {:?}", current.tokens())
+        _ => unreachable!("Encountered impossible function during parsing: {:?}", current.tokens())
     };
 
     match name {
         Some(name) => Expression::Function(name, arguments, Span::from_pest(token.as_span())),
-        _ => unreachable!("Encounterd impossible function during parsing: {:?}", token.as_str()),
+        _ => unreachable!("Encountered impossible function during parsing: {:?}", token.as_str()),
     }
 }
 
@@ -69,7 +69,7 @@ fn parse_array(token: &pest::iterators::Pair<'_, Rule>) -> Expression {
 
     match_children! { token, current,
         Rule::expression => elements.push(parse_expression(&current)),
-        _ => unreachable!("Encounterd impossible array during parsing: {:?}", current.tokens())
+        _ => unreachable!("Encountered impossible array during parsing: {:?}", current.tokens())
     };
 
     Expression::Array(elements, Span::from_pest(token.as_span()))
@@ -78,7 +78,7 @@ fn parse_array(token: &pest::iterators::Pair<'_, Rule>) -> Expression {
 fn parse_arg_value(token: &pest::iterators::Pair<'_, Rule>) -> Expression {
     match_first! { token, current,
         Rule::expression => parse_expression(&current),
-        _ => unreachable!("Encounterd impossible value during parsing: {:?}", current.tokens())
+        _ => unreachable!("Encountered impossible value during parsing: {:?}", current.tokens())
     }
 }
 
@@ -115,7 +115,7 @@ fn parse_directive_arg(token: &pest::iterators::Pair<'_, Rule>) -> Argument {
     match_children! { token, current,
         Rule::argument_name => name = Some(current.to_id()),
         Rule::argument_value => argument = Some(parse_arg_value(&current)),
-        _ => unreachable!("Encounterd impossible directive argument during parsing: {:?}", current.tokens())
+        _ => unreachable!("Encountered impossible directive argument during parsing: {:?}", current.tokens())
     };
 
     match (name, argument) {
@@ -125,7 +125,7 @@ fn parse_directive_arg(token: &pest::iterators::Pair<'_, Rule>) -> Argument {
             span: Span::from_pest(token.as_span()),
         },
         _ => panic!(
-            "Encounterd impossible directive arg during parsing: {:?}",
+            "Encountered impossible directive arg during parsing: {:?}",
             token.as_str()
         ),
     }
@@ -141,7 +141,7 @@ fn parse_directive_args(token: &pest::iterators::Pair<'_, Rule>, arguments: &mut
             value: parse_arg_value(&current),
             span: Span::from_pest(current.as_span())
         }),
-        _ => unreachable!("Encounterd impossible directive argument during parsing: {:?}", current.tokens())
+        _ => unreachable!("Encountered impossible directive argument during parsing: {:?}", current.tokens())
     }
 }
 
@@ -152,7 +152,7 @@ fn parse_directive(token: &pest::iterators::Pair<'_, Rule>) -> Directive {
     match_children! { token, current,
         Rule::directive_name => name = Some(current.to_id()),
         Rule::directive_arguments => parse_directive_args(&current, &mut arguments),
-        _ => unreachable!("Encounterd impossible directive during parsing: {:?}", current.tokens())
+        _ => unreachable!("Encountered impossible directive during parsing: {:?}", current.tokens())
     };
 
     match name {
@@ -161,7 +161,7 @@ fn parse_directive(token: &pest::iterators::Pair<'_, Rule>) -> Directive {
             arguments,
             span: Span::from_pest(token.as_span()),
         },
-        _ => panic!("Encounterd impossible type during parsing: {:?}", token.as_str()),
+        _ => panic!("Encountered impossible type during parsing: {:?}", token.as_str()),
     }
 }
 
@@ -169,7 +169,7 @@ fn parse_directive(token: &pest::iterators::Pair<'_, Rule>) -> Directive {
 fn parse_base_type(token: &pest::iterators::Pair<'_, Rule>) -> String {
     match_first! { token, current,
         Rule::identifier => current.as_str().to_string(),
-        _ => unreachable!("Encounterd impossible type during parsing: {:?}", current.tokens())
+        _ => unreachable!("Encountered impossible type during parsing: {:?}", current.tokens())
     }
 }
 
@@ -186,7 +186,7 @@ fn parse_field_type(token: &pest::iterators::Pair<'_, Rule>) -> Result<(FieldAri
             "To specify a list, please use `Type[]` instead of `[Type]`.",
             Span::from_pest(current.as_span())
         )),
-        _ => unreachable!("Encounterd impossible field during parsing: {:?}", current.tokens())
+        _ => unreachable!("Encountered impossible field during parsing: {:?}", current.tokens())
     }
 }
 
@@ -209,7 +209,7 @@ fn parse_field(token: &pest::iterators::Pair<'_, Rule>) -> Result<Field, Datamod
             Span::from_pest(current.as_span()))),
         Rule::directive => directives.push(parse_directive(&current)),
         Rule::doc_comment => comments.push(parse_doc_comment(&current)),
-        _ => unreachable!("Encounterd impossible field declaration during parsing: {:?}", current.tokens())
+        _ => unreachable!("Encountered impossible field declaration during parsing: {:?}", current.tokens())
     }
 
     match (name, field_type) {
@@ -226,7 +226,7 @@ fn parse_field(token: &pest::iterators::Pair<'_, Rule>) -> Result<Field, Datamod
             span: Span::from_pest(token.as_span()),
         }),
         _ => panic!(
-            "Encounterd impossible field declaration during parsing: {:?}",
+            "Encountered impossible field declaration during parsing: {:?}",
             token.as_str()
         ),
     }
@@ -255,7 +255,7 @@ fn parse_model(token: &pest::iterators::Pair<'_, Rule>) -> Result<Model, ErrorCo
             }
         },
         Rule::doc_comment => comments.push(parse_doc_comment(&current)),
-        _ => unreachable!("Encounterd impossible model declaration during parsing: {:?}", current.tokens())
+        _ => unreachable!("Encountered impossible model declaration during parsing: {:?}", current.tokens())
     }
 
     errors.ok()?;
@@ -269,7 +269,7 @@ fn parse_model(token: &pest::iterators::Pair<'_, Rule>) -> Result<Model, ErrorCo
             span: Span::from_pest(token.as_span()),
         }),
         _ => panic!(
-            "Encounterd impossible model declaration during parsing: {:?}",
+            "Encountered impossible model declaration during parsing: {:?}",
             token.as_str()
         ),
     }
@@ -288,7 +288,7 @@ fn parse_enum(token: &pest::iterators::Pair<'_, Rule>) -> Enum {
         Rule::directive => directives.push(parse_directive(&current)),
         Rule::enum_field_declaration => values.push(EnumValue { name: current.as_str().to_string(), span: Span::from_pest(current.as_span()) }),
         Rule::doc_comment => comments.push(parse_doc_comment(&current)),
-        _ => unreachable!("Encounterd impossible enum declaration during parsing: {:?}", current.tokens())
+        _ => unreachable!("Encountered impossible enum declaration during parsing: {:?}", current.tokens())
     }
 
     match name {
@@ -300,7 +300,7 @@ fn parse_enum(token: &pest::iterators::Pair<'_, Rule>) -> Enum {
             span: Span::from_pest(token.as_span()),
         },
         _ => panic!(
-            "Encounterd impossible enum declaration during parsing, name is missing: {:?}",
+            "Encountered impossible enum declaration during parsing, name is missing: {:?}",
             token.as_str()
         ),
     }
@@ -313,7 +313,7 @@ fn parse_key_value(token: &pest::iterators::Pair<'_, Rule>) -> Argument {
     match_children! { token, current,
         Rule::identifier => name = Some(current.to_id()),
         Rule::expression => value = Some(parse_expression(&current)),
-        _ => unreachable!("Encounterd impossible source property declaration during parsing: {:?}", current.tokens())
+        _ => unreachable!("Encountered impossible source property declaration during parsing: {:?}", current.tokens())
     }
 
     match (name, value) {
@@ -323,7 +323,7 @@ fn parse_key_value(token: &pest::iterators::Pair<'_, Rule>) -> Argument {
             span: Span::from_pest(token.as_span()),
         },
         _ => panic!(
-            "Encounterd impossible source property declaration during parsing: {:?}",
+            "Encountered impossible source property declaration during parsing: {:?}",
             token.as_str()
         ),
     }
@@ -340,7 +340,7 @@ fn parse_source(token: &pest::iterators::Pair<'_, Rule>) -> SourceConfig {
         Rule::identifier => name = Some(current.to_id()),
         Rule::key_value => properties.push(parse_key_value(&current)),
         Rule::doc_comment => comments.push(parse_doc_comment(&current)),
-        _ => unreachable!("Encounterd impossible source declaration during parsing: {:?}", current.tokens())
+        _ => unreachable!("Encountered impossible source declaration during parsing: {:?}", current.tokens())
     };
 
     match name {
@@ -351,7 +351,7 @@ fn parse_source(token: &pest::iterators::Pair<'_, Rule>) -> SourceConfig {
             span: Span::from_pest(token.as_span()),
         },
         _ => panic!(
-            "Encounterd impossible source declaration during parsing, name is missing: {:?}",
+            "Encountered impossible source declaration during parsing, name is missing: {:?}",
             token.as_str()
         ),
     }
@@ -368,7 +368,7 @@ fn parse_generator(token: &pest::iterators::Pair<'_, Rule>) -> GeneratorConfig {
         Rule::identifier => name = Some(current.to_id()),
         Rule::key_value => properties.push(parse_key_value(&current)),
         Rule::doc_comment => comments.push(parse_doc_comment(&current)),
-        _ => unreachable!("Encounterd impossible generator declaration during parsing: {:?}", current.tokens())
+        _ => unreachable!("Encountered impossible generator declaration during parsing: {:?}", current.tokens())
     };
 
     match name {
@@ -379,7 +379,7 @@ fn parse_generator(token: &pest::iterators::Pair<'_, Rule>) -> GeneratorConfig {
             span: Span::from_pest(token.as_span()),
         },
         _ => panic!(
-            "Encounterd impossible generator declaration during parsing, name is missing: {:?}",
+            "Encountered impossible generator declaration during parsing, name is missing: {:?}",
             token.as_str()
         ),
     }
@@ -400,7 +400,7 @@ fn parse_type(token: &pest::iterators::Pair<'_, Rule>) -> Field {
         },
         Rule::directive => directives.push(parse_directive(&current)),
         Rule::doc_comment => comments.push(parse_doc_comment(&current)),
-        _ => unreachable!("Encounterd impossible custom type during parsing: {:?}", current.tokens())
+        _ => unreachable!("Encountered impossible custom type during parsing: {:?}", current.tokens())
     }
 
     match (name, base_type) {
@@ -417,7 +417,7 @@ fn parse_type(token: &pest::iterators::Pair<'_, Rule>) -> Field {
             span: Span::from_pest(token.as_span()),
         },
         _ => panic!(
-            "Encounterd impossible custom type declaration during parsing: {:?}",
+            "Encountered impossible custom type declaration during parsing: {:?}",
             token.as_str()
         ),
     }
@@ -445,7 +445,7 @@ pub fn parse(datamodel_string: &str) -> Result<SchemaAst, ErrorCollection> {
                 Rule::generator_block => models.push(Top::Generator(parse_generator(&current))),
                 Rule::type_declaration => models.push(Top::Type(parse_type(&current))),
                 Rule::EOI => {},
-                _ => panic!("Encounterd impossible datamodel declaration during parsing: {:?}", current.tokens())
+                _ => panic!("Encountered impossible datamodel declaration during parsing: {:?}", current.tokens())
             }
 
             errors.ok()?;

--- a/libs/datamodel/core/src/error/mod.rs
+++ b/libs/datamodel/core/src/error/mod.rs
@@ -353,14 +353,15 @@ fn pretty_print_error(f: &mut dyn std::io::Write, file_name: &str, text: &str, e
     let span = error_obj.span();
     let error = error_obj.description();
 
-    let line_number = text[..span.start].matches("\n").count();
+    let start_line_number = text[..span.start].matches("\n").count();
+    let end_line_number = text[..span.end].matches("\n").count();
     let file_lines = text.split("\n").collect::<Vec<&str>>();
 
-    let chars_in_line_before: usize = file_lines[..line_number].iter().map(|l| l.len()).sum();
+    let chars_in_line_before: usize = file_lines[..start_line_number].iter().map(|l| l.len()).sum();
     // Don't forget to count the all the line breaks.
-    let chars_in_line_before = chars_in_line_before + line_number;
+    let chars_in_line_before = chars_in_line_before + start_line_number;
 
-    let line = &file_lines[line_number];
+    let line = &file_lines[start_line_number];
 
     let start_in_line = span.start - chars_in_line_before;
     let end_in_line = std::cmp::min(start_in_line + (span.end - span.start), line.len());
@@ -370,18 +371,23 @@ fn pretty_print_error(f: &mut dyn std::io::Write, file_name: &str, text: &str, e
     let suffix = &line[end_in_line..];
 
     let arrow = "-->".bright_blue().bold();
-    let file_path = format!("{}:{}", file_name, line_number + 1).underline();
+    let file_path = format!("{}:{}", file_name, start_line_number + 1).underline();
 
     writeln!(f, "{}: {}", "error".bright_red().bold(), error.bold())?;
     writeln!(f, "  {}  {}", arrow, file_path)?;
     writeln!(f, "{}", format_line_number(0))?;
-    writeln!(f, "{}", format_line_number_with_line(line_number, &file_lines))?;
-    writeln!(f, "{}{}{}{}", format_line_number(line_number + 1), prefix, offending, suffix)?;
+    
+    writeln!(f, "{}", format_line_number_with_line(start_line_number, &file_lines))?;
+    writeln!(f, "{}{}{}{}", format_line_number(start_line_number + 1), prefix, offending, suffix)?;
     if offending.len() == 0 {
         let spacing = std::iter::repeat(" ").take(start_in_line).collect::<String>();
         writeln!(f, "{}{}{}", format_line_number(0), spacing, "^ Unexpected token.".bold().bright_red())?;
     }
-    writeln!(f, "{}", format_line_number_with_line(line_number + 2, &file_lines))?;
+    
+    for line_number in start_line_number + 2 .. end_line_number + 2 {
+        writeln!(f, "{}", format_line_number_with_line(line_number, &file_lines))?;
+    }
+    
     writeln!(f, "{}", format_line_number(0))
 }
 

--- a/libs/datamodel/core/src/error/mod.rs
+++ b/libs/datamodel/core/src/error/mod.rs
@@ -28,7 +28,7 @@ pub enum DatamodelError {
     #[fail(display = "Argument \"{}\" is missing in generator block \"{}\".", argument_name, generator_name)]
     GeneratorArgumentNotFound { argument_name: String, generator_name: String, span: Span },
 
-    #[fail(display = "Error parsing attribute \"@{}\": {}.", directive_name, message)]
+    #[fail(display = "Error parsing attribute \"@{}\": {}", directive_name, message)]
     DirectiveValidationError { message: String, directive_name: String, span: Span },
 
     #[fail(display = "Attribute \"@{}\" is defined twice.", directive_name)]
@@ -80,7 +80,7 @@ pub enum DatamodelError {
     #[fail(display = "Type \"{}\" is not a built-in type.", type_name)]
     ScalarTypeNotFoundError { type_name: String, span: Span },
 
-    #[fail(display = "Unexpected token. Expected one of: {}.", expected_str)]
+    #[fail(display = "Unexpected token. Expected one of: {}", expected_str)]
     ParserError { expected: Vec<&'static str>, expected_str: String, span: Span },
 
     #[fail(display = "{}", message)]
@@ -95,13 +95,13 @@ pub enum DatamodelError {
     #[fail(display = "Expected a {} value, but received {} value \"{}\".", expected_type, received_type, raw)]
     TypeMismatchError { expected_type: String, received_type: String, raw: String, span: Span },
 
-    #[fail(display = "Expected a {} value, but failed while parsing \"{}\": {}.", expected_type, raw, parser_error)]
+    #[fail(display = "Expected a {} value, but failed while parsing \"{}\": {}", expected_type, raw, parser_error)]
     ValueParserError { expected_type: String, parser_error: String, raw: String, span: Span },
 
-    #[fail(display = "Error validating model \"{}\": {}.", model_name, message)]
+    #[fail(display = "Error validating model \"{}\": {}", model_name, message)]
     ModelValidationError { message: String, model_name: String, span: Span  },
 
-    #[fail(display = "Error validating: {}.", message)]
+    #[fail(display = "Error validating: {}", message)]
     ValidationError { message: String, span: Span  },
 }
 

--- a/libs/datamodel/core/src/error/mod.rs
+++ b/libs/datamodel/core/src/error/mod.rs
@@ -95,7 +95,7 @@ pub enum DatamodelError {
     #[fail(display = "Expected a {} value, but received {} value \"{}\".", expected_type, received_type, raw)]
     TypeMismatchError { expected_type: String, received_type: String, raw: String, span: Span },
 
-    #[fail(display = "Expected a {} value, but failed while parsing \"{}\": {}", expected_type, raw, parser_error)]
+    #[fail(display = "Expected a {} value, but failed while parsing \"{}\": {}.", expected_type, raw, parser_error)]
     ValueParserError { expected_type: String, parser_error: String, raw: String, span: Span },
 
     #[fail(display = "Error validating model \"{}\": {}", model_name, message)]

--- a/libs/datamodel/core/src/validator/lift.rs
+++ b/libs/datamodel/core/src/validator/lift.rs
@@ -203,7 +203,7 @@ impl LiftAstToDml {
             // Recursive type.
             return Err(DatamodelError::new_validation_error(
                 &format!(
-                    "Recursive type definitions are not allowed. Recursive path was: {} -> {}",
+                    "Recursive type definitions are not allowed. Recursive path was: {} -> {}.",
                     checked_types.join(" -> "),
                     type_name
                 ),

--- a/libs/datamodel/core/tests/directives/id_negative.rs
+++ b/libs/datamodel/core/tests/directives/id_negative.rs
@@ -62,6 +62,13 @@ fn id_should_error_on_model_without_id() {
 
     let errors = parse_error(dml);
 
+    errors
+        .errors
+        .first()
+        .unwrap()
+        .pretty_print(&mut std::io::stderr().lock(), "", dml)
+        .unwrap();
+
     errors.assert_is(DatamodelError::new_model_validation_error(
         "Each model must have exactly one id criteria. Either mark a single field with `@id` or add a multi field id criterion with `@@id([])` to the model.",
         "Model",

--- a/libs/datamodel/core/tests/directives/id_negative.rs
+++ b/libs/datamodel/core/tests/directives/id_negative.rs
@@ -62,13 +62,6 @@ fn id_should_error_on_model_without_id() {
 
     let errors = parse_error(dml);
 
-    errors
-        .errors
-        .first()
-        .unwrap()
-        .pretty_print(&mut std::io::stderr().lock(), "", dml)
-        .unwrap();
-
     errors.assert_is(DatamodelError::new_model_validation_error(
         "Each model must have exactly one id criteria. Either mark a single field with `@id` or add a multi field id criterion with `@@id([])` to the model.",
         "Model",

--- a/libs/datamodel/core/tests/types/negative.rs
+++ b/libs/datamodel/core/tests/types/negative.rs
@@ -47,7 +47,7 @@ fn shound_fail_on_directive_duplication_recursive() {
 }
 
 #[test]
-fn shound_fail_on_endless_recursive_type_def() {
+fn should_fail_on_endless_recursive_type_def() {
     let dml = r#"
     type MyString = ID
     type MyStringWithDefault = MyString
@@ -61,7 +61,7 @@ fn shound_fail_on_endless_recursive_type_def() {
     let error = parse_error(dml);
 
     error.assert_is(DatamodelError::new_validation_error(
-        "Recursive type definitions are not allowed. Recursive path was: ID -> MyStringWithDefault -> MyString -> ID",
+        "Recursive type definitions are not allowed. Recursive path was: ID -> MyStringWithDefault -> MyString -> ID.",
         ast::Span::new(21, 23),
     ));
 }

--- a/libs/prisma-models/src/fields.rs
+++ b/libs/prisma-models/src/fields.rs
@@ -38,7 +38,7 @@ impl Fields {
                         Field::Scalar(sf) if sf.is_id() => Some(Arc::downgrade(sf)),
                         _ => acc,
                     })
-                    .expect("No id field defined!")
+                    .expect(format!("No id field defined! Model: {}", (self.model.upgrade().unwrap().name)).as_str())
             })
             .upgrade()
             .unwrap()

--- a/libs/prisma-models/src/fields.rs
+++ b/libs/prisma-models/src/fields.rs
@@ -38,7 +38,8 @@ impl Fields {
                         Field::Scalar(sf) if sf.is_id() => Some(Arc::downgrade(sf)),
                         _ => acc,
                     })
-                    .expect(format!("No id field defined! Model: {}", (self.model.upgrade().unwrap().name)).as_str())
+                    .ok_or_else(|| format!("No id field defined! Model: {}", (self.model.upgrade().unwrap().name)))
+                    .unwrap()
             })
             .upgrade()
             .unwrap()


### PR DESCRIPTION
* Print out full error span in error message
* Avoid producing double dots at end of error messages.
* Try to provide the model in the No Id defined panic