### PR TITLE
Skip join from pagination queries if possible

### DIFF
--- a/libs/prisma-models/src/sql_ext/relation.rs
+++ b/libs/prisma-models/src/sql_ext/relation.rs
@@ -14,8 +14,8 @@ pub trait RelationExt {
 }
 
 pub trait RelationFieldExt {
-    fn opposite_column(&self) -> Column<'static>;
-    fn relation_column(&self) -> Column<'static>;
+    fn opposite_column(&self, alias: bool) -> Column<'static>;
+    fn relation_column(&self, alias: bool) -> Column<'static>;
 }
 
 pub trait InlineRelationExt {
@@ -30,17 +30,29 @@ impl InlineRelationExt for InlineRelation {
 }
 
 impl RelationFieldExt for RelationField {
-    fn opposite_column(&self) -> Column<'static> {
-        match self.relation_side {
+    fn opposite_column(&self, alias: bool) -> Column<'static> {
+        let col = match self.relation_side {
             RelationSide::A => self.relation().model_b_column(),
             RelationSide::B => self.relation().model_a_column(),
+        };
+
+        if alias && !self.relation_is_inlined_in_child() {
+            col.table(Relation::TABLE_ALIAS)
+        } else {
+            col
         }
     }
 
-    fn relation_column(&self) -> Column<'static> {
-        match self.relation_side {
+    fn relation_column(&self, alias: bool) -> Column<'static> {
+        let col = match self.relation_side {
             RelationSide::A => self.relation().model_a_column(),
             RelationSide::B => self.relation().model_b_column(),
+        };
+
+        if alias && !self.relation_is_inlined_in_child() {
+            col.table(Relation::TABLE_ALIAS)
+        } else {
+            col
         }
     }
 }

--- a/query-engine/connectors/sql-query-connector/src/database/connection.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/connection.rs
@@ -1,8 +1,8 @@
 use super::transaction::SqlConnectorTransaction;
 use crate::{database::operations::*, query_builder::read::ManyRelatedRecordsQueryBuilder, QueryExt, SqlError};
 use connector_interface::{
-    self as connector, filter::Filter, Connection, QueryArguments, ReadOperations, Transaction,
-    WriteArgs, WriteOperations, IO,
+    self as connector, filter::Filter, Connection, QueryArguments, ReadOperations, Transaction, WriteArgs,
+    WriteOperations, IO,
 };
 use prisma_models::prelude::*;
 use quaint::{connector::TransactionCapable, prelude::ConnectionInfo};

--- a/query-engine/connectors/sql-query-connector/src/database/transaction.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/transaction.rs
@@ -1,8 +1,7 @@
 use crate::database::operations::*;
 use crate::{query_builder::read::ManyRelatedRecordsQueryBuilder, SqlError};
 use connector_interface::{
-    self as connector, filter::Filter, QueryArguments, ReadOperations, Transaction, WriteArgs,
-    WriteOperations, IO,
+    self as connector, filter::Filter, QueryArguments, ReadOperations, Transaction, WriteArgs, WriteOperations, IO,
 };
 use prisma_models::prelude::*;
 use quaint::prelude::ConnectionInfo;

--- a/query-engine/connectors/sql-query-connector/src/filter_conversion.rs
+++ b/query-engine/connectors/sql-query-connector/src/filter_conversion.rs
@@ -207,8 +207,8 @@ impl AliasedSelect for RelationFilter {
         let condition = self.condition.clone();
         let relation = self.field.relation();
 
-        let this_column = self.field.relation_column().table(alias.to_string(None));
-        let other_column = self.field.opposite_column().table(alias.to_string(None));
+        let this_column = self.field.relation_column(false).table(alias.to_string(None));
+        let other_column = self.field.opposite_column(false).table(alias.to_string(None));
 
         // Normalize filter tree
         let compacted = match *self.nested_filter {

--- a/query-engine/connectors/sql-query-connector/src/query_builder/read/many_related_records/mod.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/read/many_related_records/mod.rs
@@ -20,13 +20,12 @@ pub trait ManyRelatedRecordsQueryBuilder {
     fn without_pagination<'a>(base: ManyRelatedRecordsBaseQuery<'a>) -> Query {
         let conditions = base
             .from_field
-            .relation_column()
-            .table(Relation::TABLE_ALIAS)
+            .relation_column(true)
             .in_selection(base.from_record_ids.to_owned())
             .and(base.condition)
             .and(base.cursor);
 
-        let opposite_column = base.from_field.opposite_column().table(Relation::TABLE_ALIAS);
+        let opposite_column = base.from_field.opposite_column(true);
         let order_columns = Ordering::internal(opposite_column, base.order_directions);
 
         order_columns

--- a/query-engine/connectors/sql-query-connector/src/query_builder/read/many_related_records/row_number.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/read/many_related_records/row_number.rs
@@ -9,8 +9,7 @@ impl ManyRelatedRecordsQueryBuilder for ManyRelatedRecordsWithRowNumber {
     fn with_pagination(base: ManyRelatedRecordsBaseQuery) -> Query {
         let conditions = base
             .from_field
-            .relation_column()
-            .table(Relation::TABLE_ALIAS)
+            .relation_column(true)
             .in_selection(base.from_record_ids.to_owned())
             .and(base.condition)
             .and(base.cursor);

--- a/query-engine/connectors/sql-query-connector/src/query_builder/read/many_related_records/union_all.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/read/many_related_records/union_all.rs
@@ -31,19 +31,16 @@ impl ManyRelatedRecordsQueryBuilder for ManyRelatedRecordsWithUnionAll {
         let base_query = order_columns.into_iter().fold(base_query, |acc, ord| acc.order_by(ord));
         let mut distinct_ids = distinct_ids.into_iter();
 
-
         let build_cond = |id| {
             let conditions = base_condition
                 .clone()
-                .and(from_field.relation_column().table(Relation::TABLE_ALIAS).equals(id));
+                .and(from_field.relation_column(true).equals(id));
 
             base_query.clone().so_that(conditions)
         };
 
         if let Some(id) = distinct_ids.nth(0) {
-            let union = distinct_ids.fold(Union::new(build_cond(id)), |acc, id| {
-                acc.all(build_cond(id))
-            });
+            let union = distinct_ids.fold(Union::new(build_cond(id)), |acc, id| acc.all(build_cond(id)));
 
             Query::from(union)
         } else {

--- a/query-engine/connectors/sql-query-connector/src/query_builder/read/mod.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/read/mod.rs
@@ -67,12 +67,11 @@ impl SelectDefinition for QueryArguments {
     }
 }
 
-pub fn get_records<T>(model: &ModelRef, columns: impl Iterator<Item=Column<'static>>, query: T) -> Select<'static>
+pub fn get_records<T>(model: &ModelRef, columns: impl Iterator<Item = Column<'static>>, query: T) -> Select<'static>
 where
     T: SelectDefinition,
 {
-    columns
-        .fold(query.into_select(model), |acc, col| acc.column(col))
+    columns.fold(query.into_select(model), |acc, col| acc.column(col))
 }
 
 pub fn count_by_model(model: &ModelRef, query_arguments: QueryArguments) -> Select<'static> {

--- a/query-engine/connectors/sql-query-connector/src/query_builder/write/mod.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/write/mod.rs
@@ -46,8 +46,8 @@ pub fn create_relation_table_records(
     child_ids: &[GraphqlId],
 ) -> Query<'static> {
     let relation = field.relation();
-    let parent_column = field.relation_column();
-    let child_column = field.opposite_column();
+    let parent_column = field.relation_column(false);
+    let child_column = field.opposite_column(false);
 
     let mut columns = vec![parent_column.name.to_string(), child_column.name.to_string()];
     if let Some(id_col) = relation.id_column() {
@@ -76,8 +76,8 @@ pub fn delete_relation_table_records(
     child_ids: &[GraphqlId],
 ) -> Query<'static> {
     let relation = field.relation();
-    let parent_column = field.relation_column();
-    let child_column = field.opposite_column();
+    let parent_column = field.relation_column(false);
+    let child_column = field.opposite_column(false);
 
     let parent_id_criteria = parent_column.equals(parent_id);
     let child_id_criteria = child_column.in_selection(child_ids.to_owned());

--- a/query-engine/connectors/sql-query-connector/src/query_ext.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_ext.rs
@@ -1,6 +1,7 @@
 use crate::{error::*, AliasedCondition, RawQuery, SqlRow, ToSqlRow};
 use async_trait::async_trait;
 use connector_interface::filter::Filter;
+use datamodel::FieldArity;
 use prisma_models::*;
 use quaint::{
     ast::*,
@@ -8,7 +9,6 @@ use quaint::{
     pooled::PooledConnection,
 };
 use serde_json::{Map, Number, Value};
-use datamodel::FieldArity;
 use std::convert::TryFrom;
 
 impl<'t> QueryExt for connector::Transaction<'t> {}
@@ -86,7 +86,9 @@ pub trait QueryExt: Queryable + Send + Sync {
     }
 
     async fn select_ids(&self, select: Select<'_>) -> crate::Result<Vec<GraphqlId>> {
-        let mut rows = self.filter(select.into(), &[(TypeIdentifier::GraphQLID, FieldArity::Required)]).await?;
+        let mut rows = self
+            .filter(select.into(), &[(TypeIdentifier::GraphQLID, FieldArity::Required)])
+            .await?;
         let mut result = Vec::new();
 
         for mut row in rows.drain(0..) {


### PR DESCRIPTION
In cases where inlined in the child, we don't need to join in the pagination queries. Also makes aliasing much simpler as a nice side product.