### PR TITLE
[blocked] Tables without primary key in the migration engine

### DIFF
--- a/migration-engine/core/src/tests/migration_tests.rs
+++ b/migration-engine/core/src/tests/migration_tests.rs
@@ -2038,3 +2038,25 @@ async fn join_tables_between_models_with_mapped_compound_primary_keys_must_work(
 
     Ok(())
 }
+
+#[test_each_connector]
+async fn tables_without_primary_key_can_be_created(api: &TestApi) -> TestResult {
+    let dm = r#"
+        model Fruit {
+            name String
+            size Int
+        }
+    "#;
+
+    api.infer_apply(dm).send().await?;
+
+    api.assert_schema()
+        .await?
+        .assert_table("Fruit", |table| {
+            table
+                .assert_no_pk()?
+                .assert_has_column("name")?
+                .assert_has_column("size")
+        })
+        .map(drop)
+}

--- a/migration-engine/core/src/tests/test_harness/assertions.rs
+++ b/migration-engine/core/src/tests/test_harness/assertions.rs
@@ -91,6 +91,16 @@ impl<'a> TableAssertion<'a> {
         Ok(this)
     }
 
+    pub fn assert_no_pk(self) -> AssertionResult<Self> {
+        anyhow::ensure!(
+            self.0.primary_key.is_none(),
+            "assertion failed. Expected no primary key on {}, found one.",
+            self.0.name
+        );
+
+        Ok(self)
+    }
+
     pub fn assert_pk<F>(self, pk_assertions: F) -> AssertionResult<Self>
     where
         F: FnOnce(PrimaryKeyAssertion<'a>) -> AssertionResult<PrimaryKeyAssertion<'a>>,

--- a/migration-engine/core/src/tests/test_harness/test_api.rs
+++ b/migration-engine/core/src/tests/test_harness/test_api.rs
@@ -1,3 +1,4 @@
+use super::assertions::SchemaAssertion;
 use super::{
     command_helpers::{run_infer_command, InferOutput},
     misc_helpers::{mysql_migration_connector, postgres_migration_connector, sqlite_migration_connector, test_api},
@@ -200,6 +201,12 @@ impl TestApi {
         result.tables = result.tables.into_iter().filter(|t| t.name != "_Migration").collect();
 
         Ok(result)
+    }
+
+    pub async fn assert_schema(&self) -> Result<SchemaAssertion, anyhow::Error> {
+        let schema = self.describe_database().await?;
+
+        Ok(SchemaAssertion(schema))
     }
 }
 


### PR DESCRIPTION
Not possible to migrate at the moment because the datamodel parser validates for the presence of an ID.