### PR TITLE
Test that migration-engine does not create superfluous indexes on mysql

### DIFF
--- a/migration-engine/core/src/tests/migration_tests.rs
+++ b/migration-engine/core/src/tests/migration_tests.rs
@@ -1,5 +1,6 @@
 mod indexes;
 mod mariadb;
+mod mysql;
 mod sqlite;
 
 use super::test_harness::*;
@@ -1769,14 +1770,14 @@ async fn relations_can_reference_multiple_fields_with_mappings(api: &TestApi) ->
     "#;
 
     api.infer_apply(dm).send().await?;
-    let schema = api.describe_database().await?;
 
-    schema
-        .assert_table("Account")?
-        .assert_foreign_keys_count(1)?
-        .assert_fk_on_columns(&["user_emergency-mail", "user_birthdays-count"], |fk| {
-            fk.assert_references("users", &["emergency-mail", "birthdays-count"])
-        })?;
+    api.assert_schema().await?.assert_table("Account", |table| {
+        table
+            .assert_foreign_keys_count(1)?
+            .assert_fk_on_columns(&["user_emergency-mail", "user_birthdays-count"], |fk| {
+                fk.assert_references("users", &["emergency-mail", "birthdays-count"])
+            })
+    })?;
 
     Ok(())
 }
@@ -1795,12 +1796,10 @@ async fn foreign_keys_are_added_on_existing_tables(api: &TestApi) -> TestResult 
     "#;
 
     api.infer_apply(dm1).send().await?;
-    let schema = api.describe_database().await?;
-
-    anyhow::ensure!(
-        schema.table("Account").ok().map(|table| table.foreign_keys.is_empty()) == Some(true),
-        "There should be no foreign key yet."
-    );
+    api.assert_schema()
+        .await?
+        // There should be no foreign keys yet.
+        .assert_table("Account", |table| table.assert_foreign_keys_count(0))?;
 
     let dm2 = r#"
         model User {
@@ -1815,17 +1814,11 @@ async fn foreign_keys_are_added_on_existing_tables(api: &TestApi) -> TestResult 
     "#;
 
     api.infer_apply(dm2).send().await?;
-    let schema = api.describe_database().await?;
-
-    let table = schema.table("Account").map_err(|err| anyhow::anyhow!("{}", err))?;
-
-    assert_eq!(table.foreign_keys.len(), 1);
-
-    let fk = table.foreign_keys.iter().next().unwrap();
-
-    assert_eq!(fk.columns, &["user"]);
-    assert_eq!(fk.referenced_table, "User");
-    assert_eq!(fk.referenced_columns, &["email"]);
+    api.assert_schema().await?.assert_table("Account", |table| {
+        table
+            .assert_foreign_keys_count(1)?
+            .assert_fk_on_columns(&["user"], |fk| fk.assert_references("User", &["email"]))
+    })?;
 
     Ok(())
 }

--- a/migration-engine/core/src/tests/migration_tests/mysql.rs
+++ b/migration-engine/core/src/tests/migration_tests/mysql.rs
@@ -1,0 +1,38 @@
+use crate::tests::test_harness::*;
+
+/// We need to test this specifically for mysql, because foreign keys are indexes, and they are
+/// inferred as both foreign key and index by the sql-schema-describer. We do not want to
+/// create/delete a second index.
+#[test_one_connector(connector = "mysql")]
+async fn indexes_on_foreign_key_fields_are_not_created_twice(api: &TestApi) -> TestResult {
+    let schema = r#"
+        model Human {
+            id String @id
+            cat Cat @relation(references: [name])
+        }
+
+        model Cat {
+            id String @id
+            name String @unique
+            humans Human[]
+        }
+    "#;
+
+    api.infer_apply(schema).send().await?;
+
+    let sql_schema = api
+        .assert_schema()
+        .await?
+        .assert_table("Human", |table| {
+            table
+                .assert_foreign_keys_count(1)?
+                .assert_fk_on_columns(&["cat"], |fk| fk.assert_references("Cat", &["name"]))?
+                .assert_indexes_count(1)?
+                .assert_index_on_columns(&["cat"], |idx| idx.assert_is_not_unique())
+        })?
+        .into_schema();
+
+    // Test that after introspection, we do not migrate further.
+    api.infer_apply(schema).force(Some(true)).send().await?;
+    api.assert_schema().await?.assert_equals(&sql_schema).map(drop)
+}


### PR DESCRIPTION
Blocked on the sql-schema-describer changes.