### PR TITLE
Lift the 'static bound on MigrationConnector components

### DIFF
--- a/migration-engine/connectors/migration-connector/src/database_migration_inferrer.rs
+++ b/migration-engine/connectors/migration-connector/src/database_migration_inferrer.rs
@@ -5,7 +5,7 @@ use datamodel::Datamodel;
 /// migrating the database from one datamodel to another. In addition to the datamodel information provided by the core, a connector
 /// may gather additional information itself, e.g. through looking at the description of the underlying database.
 #[async_trait::async_trait]
-pub trait DatabaseMigrationInferrer<T>: Send + Sync + 'static {
+pub trait DatabaseMigrationInferrer<T>: Send + Sync {
     /// Infer the database migration steps. The previous datamodel is provided, but the implementor can ignore it.
     async fn infer(&self, previous: &Datamodel, next: &Datamodel, steps: &[MigrationStep]) -> ConnectorResult<T>;
 

--- a/migration-engine/connectors/migration-connector/src/database_migration_step_applier.rs
+++ b/migration-engine/connectors/migration-connector/src/database_migration_step_applier.rs
@@ -3,7 +3,7 @@ use crate::*;
 /// Apply a single migration step to the connector's database. At this level, we are working with database migrations,
 /// i.e. the [associated type on MigrationConnector](trait.MigrationConnector.html#associatedtype.DatabaseMigration).
 #[async_trait::async_trait]
-pub trait DatabaseMigrationStepApplier<T>: Send + Sync + 'static {
+pub trait DatabaseMigrationStepApplier<T>: Send + Sync {
     /// Applies the step to the database
     /// Returns true to signal to the caller that there are more steps to apply.
     async fn apply_step(&self, database_migration: &T, step: usize) -> ConnectorResult<bool>;

--- a/migration-engine/connectors/migration-connector/src/destructive_changes_checker.rs
+++ b/migration-engine/connectors/migration-connector/src/destructive_changes_checker.rs
@@ -7,7 +7,7 @@ use std::marker::PhantomData;
 /// The type parameter is the connector's [DatabaseMigration](trait.MigrationConnector.html#associatedtype.DatabaseMigration)
 /// type.
 #[async_trait::async_trait]
-pub trait DestructiveChangesChecker<T>: Send + Sync + 'static
+pub trait DestructiveChangesChecker<T>: Send + Sync
 where
     T: Send + Sync + 'static,
 {

--- a/migration-engine/connectors/migration-connector/src/migration_persistence.rs
+++ b/migration-engine/connectors/migration-connector/src/migration_persistence.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 
 /// This trait is implemented by each connector. It provides a generic API to store and retrieve [Migration](struct.Migration.html) records.
 #[async_trait::async_trait]
-pub trait MigrationPersistence: Send + Sync + 'static {
+pub trait MigrationPersistence: Send + Sync {
     /// Initialize migration persistence state. E.g. create the migrations table in an SQL database.
     async fn init(&self) -> Result<(), ConnectorError>;
 

--- a/migration-engine/connectors/sql-migration-connector/src/component.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/component.rs
@@ -1,0 +1,35 @@
+use crate::{DatabaseInfo, SqlMigrationConnector, SqlResult};
+use quaint::prelude::{ConnectionInfo, Queryable, SqlFamily};
+
+#[async_trait::async_trait]
+pub(crate) trait Component {
+    fn connector(&self) -> &SqlMigrationConnector;
+
+    fn schema_name(&self) -> &str {
+        &self.connector().schema_name
+    }
+
+    fn connection_info(&self) -> &ConnectionInfo {
+        self.connector().connection_info()
+    }
+
+    fn conn(&self) -> &dyn Queryable {
+        self.connector().database.as_ref()
+    }
+
+    fn database_info(&self) -> &DatabaseInfo {
+        &self.connector().database_info
+    }
+
+    async fn describe(&self) -> SqlResult<sql_schema_describer::SqlSchema> {
+        Ok(self
+            .connector()
+            .database_describer
+            .describe(&self.schema_name())
+            .await?)
+    }
+
+    fn sql_family(&self) -> SqlFamily {
+        self.connection_info().sql_family()
+    }
+}

--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_migration_inferrer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_migration_inferrer.rs
@@ -5,16 +5,19 @@ use datamodel::*;
 use migration_connector::steps::MigrationStep;
 use migration_connector::*;
 use sql_schema_describer::*;
-use std::sync::Arc;
 
-pub struct SqlDatabaseMigrationInferrer {
-    pub connection_info: ConnectionInfo,
-    pub describer: Arc<dyn SqlSchemaDescriberBackend + Send + Sync + 'static>,
-    pub schema_name: String,
+pub struct SqlDatabaseMigrationInferrer<'a> {
+    pub connector: &'a crate::SqlMigrationConnector,
+}
+
+impl Component for SqlDatabaseMigrationInferrer<'_> {
+    fn connector(&self) -> &crate::SqlMigrationConnector {
+        self.connector
+    }
 }
 
 #[async_trait::async_trait]
-impl DatabaseMigrationInferrer<SqlMigration> for SqlDatabaseMigrationInferrer {
+impl DatabaseMigrationInferrer<SqlMigration> for SqlDatabaseMigrationInferrer<'_> {
     async fn infer(
         &self,
         _previous: &Datamodel,
@@ -22,17 +25,17 @@ impl DatabaseMigrationInferrer<SqlMigration> for SqlDatabaseMigrationInferrer {
         _steps: &[MigrationStep],
     ) -> ConnectorResult<SqlMigration> {
         let fut = async {
-            let current_database_schema: SqlSchema = self.describe(&self.schema_name).await?;
+            let current_database_schema: SqlSchema = self.describe().await?;
             let expected_database_schema = SqlSchemaCalculator::calculate(next)?;
             infer(
                 &current_database_schema,
                 &expected_database_schema,
-                &self.schema_name,
+                self.schema_name(),
                 self.sql_family(),
             )
         };
 
-        catch(&self.connection_info, fut).await
+        catch(&self.connection_info(), fut).await
     }
 
     async fn infer_from_datamodels(
@@ -47,22 +50,12 @@ impl DatabaseMigrationInferrer<SqlMigration> for SqlDatabaseMigrationInferrer {
             infer(
                 &current_database_schema,
                 &expected_database_schema,
-                &self.schema_name,
+                self.schema_name(),
                 self.sql_family(),
             )
         })();
 
-        result.map_err(|sql_error| sql_error.into_connector_error(&self.connection_info))
-    }
-}
-
-impl SqlDatabaseMigrationInferrer {
-    async fn describe(&self, schema: &str) -> SqlResult<SqlSchema> {
-        Ok(self.describer.describe(&schema).await?)
-    }
-
-    fn sql_family(&self) -> SqlFamily {
-        self.connection_info.sql_family()
+        result.map_err(|sql_error| sql_error.into_connector_error(self.connection_info()))
     }
 }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -1,17 +1,21 @@
 use crate::*;
-use quaint::prelude::Queryable;
 use sql_renderer::SqlRenderer;
 use sql_schema_describer::*;
-use std::{fmt::Write as _, sync::Arc};
+use std::fmt::Write as _;
 use tracing_futures::Instrument;
 
-pub struct SqlDatabaseStepApplier {
-    pub database_info: DatabaseInfo,
-    pub conn: Arc<dyn Queryable + Send + Sync + 'static>,
+pub struct SqlDatabaseStepApplier<'a> {
+    pub connector: &'a crate::SqlMigrationConnector,
+}
+
+impl crate::component::Component for SqlDatabaseStepApplier<'_> {
+    fn connector(&self) -> &crate::SqlMigrationConnector {
+        self.connector
+    }
 }
 
 #[async_trait::async_trait]
-impl DatabaseMigrationStepApplier<SqlMigration> for SqlDatabaseStepApplier {
+impl DatabaseMigrationStepApplier<SqlMigration> for SqlDatabaseStepApplier<'_> {
     async fn apply_step(&self, database_migration: &SqlMigration, index: usize) -> ConnectorResult<bool> {
         let renderer = self.renderer();
         let fut = self
@@ -41,23 +45,22 @@ impl DatabaseMigrationStepApplier<SqlMigration> for SqlDatabaseStepApplier {
     }
 
     fn render_steps_pretty(&self, database_migration: &SqlMigration) -> ConnectorResult<Vec<serde_json::Value>> {
-        Ok(render_steps_pretty(
+        render_steps_pretty(
             &database_migration,
             self.renderer().as_ref(),
-            &self.database_info,
+            self.database_info(),
             &database_migration.before,
         )?
         .into_iter()
-        .map(|pretty_step| serde_json::to_value(&pretty_step).unwrap())
-        .collect())
+        .map(|pretty_step| {
+            serde_json::to_value(&pretty_step)
+                .map_err(|err| ConnectorError::from_kind(migration_connector::ErrorKind::Generic(err.into())))
+        })
+        .collect()
     }
 }
 
-impl SqlDatabaseStepApplier {
-    fn connection_info(&self) -> &ConnectionInfo {
-        &self.database_info.connection_info
-    }
-
+impl SqlDatabaseStepApplier<'_> {
     async fn apply_next_step(
         &self,
         steps: &[SqlMigrationStep],
@@ -73,12 +76,12 @@ impl SqlDatabaseStepApplier {
         let step = &steps[index];
         tracing::debug!(?step);
 
-        for sql_string in render_raw_sql(&step, renderer, &self.database_info, current_schema)
+        for sql_string in render_raw_sql(&step, renderer, self.database_info(), current_schema)
             .map_err(|err: anyhow::Error| SqlError::Generic(err))?
         {
             tracing::debug!(index, %sql_string);
 
-            let result = self.conn.query_raw(&sql_string, &[]).await;
+            let result = self.conn().query_raw(&sql_string, &[]).await;
 
             // TODO: this does not evaluate the results of SQLites PRAGMA foreign_key_check
             result?;
@@ -86,10 +89,6 @@ impl SqlDatabaseStepApplier {
 
         let has_more = steps.get(index + 1).is_some();
         Ok(has_more)
-    }
-
-    fn sql_family(&self) -> SqlFamily {
-        self.connection_info().sql_family()
     }
 
     fn renderer<'a>(&'a self) -> Box<dyn SqlRenderer + Send + Sync + 'a> {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration_persistence.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration_persistence.rs
@@ -1,98 +1,88 @@
+use crate::Component;
 use barrel::types;
 use chrono::*;
 use migration_connector::*;
 use quaint::ast::*;
 use quaint::{
-    connector::{Queryable, ResultSet},
+    connector::ResultSet,
     prelude::{ConnectionInfo, SqlFamily},
 };
-use std::sync::Arc;
 use tracing::debug;
 
-pub struct SqlMigrationPersistence {
-    pub connection_info: ConnectionInfo,
-    pub connection: Arc<dyn Queryable + Send + Sync + 'static>,
-    pub schema_name: String,
+pub struct SqlMigrationPersistence<'a> {
+    pub connector: &'a crate::SqlMigrationConnector,
 }
 
-impl SqlMigrationPersistence {
-    async fn catch<O>(
-        &self,
-        fut: impl std::future::Future<Output = Result<O, super::SqlError>>,
-    ) -> Result<O, ConnectorError> {
-        match fut.await {
-            Ok(o) => Ok(o),
-            Err(sql_error) => Err(sql_error.into_connector_error(&self.connection_info)),
-        }
+impl Component for SqlMigrationPersistence<'_> {
+    fn connector(&self) -> &crate::SqlMigrationConnector {
+        self.connector
     }
 }
 
 #[async_trait::async_trait]
-impl MigrationPersistence for SqlMigrationPersistence {
+impl MigrationPersistence for SqlMigrationPersistence<'_> {
     async fn init(&self) -> Result<(), ConnectorError> {
-        self.catch(async {
-            let sql_str = match self.connection_info.sql_family() {
+        let fut = async {
+            let sql_str = match self.sql_family() {
                 SqlFamily::Sqlite => {
-                    let mut m = barrel::Migration::new().schema(self.schema_name.clone());
+                    let mut m = barrel::Migration::new().schema(self.schema_name());
                     m.create_table_if_not_exists(TABLE_NAME, migration_table_setup_sqlite);
                     m.make_from(barrel::SqlVariant::Sqlite)
                 }
                 SqlFamily::Postgres => {
-                    let mut m = barrel::Migration::new().schema(self.schema_name.clone());
+                    let mut m = barrel::Migration::new().schema(self.schema_name());
                     m.create_table(TABLE_NAME, migration_table_setup_postgres);
                     m.make_from(barrel::SqlVariant::Pg)
                 }
                 SqlFamily::Mysql => {
                     // work around barrels missing quoting
-                    let mut m = barrel::Migration::new().schema(format!("{}", self.schema_name.clone()));
+                    let mut m = barrel::Migration::new().schema(self.schema_name());
                     m.create_table(format!("{}", TABLE_NAME), migration_table_setup_mysql);
                     m.make_from(barrel::SqlVariant::Mysql)
                 }
             };
 
-            self.connection.query_raw(&sql_str, &[]).await.ok();
+            self.conn().query_raw(&sql_str, &[]).await.ok();
 
             Ok(())
-        })
-        .await
+        };
+
+        crate::catch(self.connection_info(), fut).await
     }
 
     async fn reset(&self) -> Result<(), ConnectorError> {
-        self.catch(async {
-            let sql_str = format!(r#"DELETE FROM "{}"."_Migration";"#, self.schema_name); // TODO: this is not vendor agnostic yet
-            self.connection.query_raw(&sql_str, &[]).await.ok();
+        crate::catch(self.connection_info(), async {
+            let sql_str = format!(r#"DELETE FROM "{}"."_Migration";"#, self.schema_name()); // TODO: this is not vendor agnostic yet
+            self.conn().query_raw(&sql_str, &[]).await.ok();
 
             // TODO: this is the wrong place to do that
-            match &self.connection_info {
+            match &self.connection_info() {
                 ConnectionInfo::Postgres(_) => {
-                    let sql_str = format!(r#"DROP SCHEMA "{}" CASCADE;"#, self.schema_name);
+                    let sql_str = format!(r#"DROP SCHEMA "{}" CASCADE;"#, self.schema_name());
                     debug!("{}", sql_str);
 
-                    self.connection.query_raw(&sql_str, &[]).await.ok();
+                    self.conn().query_raw(&sql_str, &[]).await.ok();
                 }
                 ConnectionInfo::Sqlite { file_path, .. } => {
-                    self.connection
-                        .execute_raw(
-                            "DETACH DATABASE ?",
-                            &[ParameterizedValue::from(self.schema_name.as_str())],
-                        )
+                    self.conn()
+                        .execute_raw("DETACH DATABASE ?", &[ParameterizedValue::from(self.schema_name())])
                         .await
                         .ok();
                     std::fs::remove_file(file_path).ok(); // ignore potential errors
-                    self.connection
+                    self.conn()
                         .execute_raw(
                             "ATTACH DATABASE ? AS ?",
                             &[
                                 ParameterizedValue::from(file_path.as_str()),
-                                ParameterizedValue::from(self.schema_name.as_str()),
+                                ParameterizedValue::from(self.schema_name()),
                             ],
                         )
                         .await?;
                 }
                 ConnectionInfo::Mysql(_) => {
-                    let sql_str = format!(r#"DROP SCHEMA `{}`;"#, self.schema_name);
+                    let sql_str = format!(r#"DROP SCHEMA `{}`;"#, self.schema_name());
                     debug!("{}", sql_str);
-                    self.connection.query_raw(&sql_str, &[]).await?;
+                    self.conn().query_raw(&sql_str, &[]).await?;
                 }
             };
 
@@ -102,36 +92,36 @@ impl MigrationPersistence for SqlMigrationPersistence {
     }
 
     async fn last(&self) -> Result<Option<Migration>, ConnectorError> {
-        self.catch(async {
+        crate::catch(self.connection_info(), async {
             let conditions = STATUS_COLUMN.equals(MigrationStatus::MigrationSuccess.code());
             let query = Select::from_table(self.table())
                 .so_that(conditions)
                 .order_by(REVISION_COLUMN.descend());
 
-            let result_set = self.connection.query(query.into()).await?;
+            let result_set = self.conn().query(query.into()).await?;
             Ok(parse_rows_new(result_set).into_iter().next())
         })
         .await
     }
 
     async fn load_all(&self) -> Result<Vec<Migration>, ConnectorError> {
-        self.catch(async {
+        crate::catch(self.connection_info(), async {
             let query = Select::from_table(self.table()).order_by(REVISION_COLUMN.ascend());
 
-            let result_set = self.connection.query(query.into()).await?;
+            let result_set = self.conn().query(query.into()).await?;
             Ok(parse_rows_new(result_set))
         })
         .await
     }
 
     async fn by_name(&self, name: &str) -> Result<Option<Migration>, ConnectorError> {
-        self.catch(async {
+        crate::catch(self.connection_info(), async {
             let conditions = NAME_COLUMN.equals(name);
             let query = Select::from_table(self.table())
                 .so_that(conditions)
                 .order_by(REVISION_COLUMN.descend());
 
-            let result_set = self.connection.query(query.into()).await?;
+            let result_set = self.conn().query(query.into()).await?;
             Ok(parse_rows_new(result_set).into_iter().next())
         })
         .await
@@ -155,9 +145,9 @@ impl MigrationPersistence for SqlMigrationPersistence {
             .value(STARTED_AT_COLUMN, self.convert_datetime(migration.started_at))
             .value(FINISHED_AT_COLUMN, ParameterizedValue::Null);
 
-        match self.connection_info.sql_family() {
+        match self.sql_family() {
             SqlFamily::Sqlite | SqlFamily::Mysql => {
-                let id = self.connection.execute(insert.into()).await.unwrap();
+                let id = self.conn().execute(insert.into()).await.unwrap();
                 match id {
                     Some(quaint::ast::Id::Int(id)) => cloned.revision = id,
                     _ => panic!("This insert must return an int"),
@@ -165,7 +155,7 @@ impl MigrationPersistence for SqlMigrationPersistence {
             }
             SqlFamily::Postgres => {
                 let returning_insert = Insert::from(insert).returning(vec!["revision"]);
-                let result_set = self.connection.query(returning_insert.into()).await.unwrap();
+                let result_set = self.conn().query(returning_insert.into()).await.unwrap();
                 result_set.into_iter().next().map(|row| {
                     cloned.revision = row["revision"].as_i64().unwrap() as usize;
                 });
@@ -176,7 +166,7 @@ impl MigrationPersistence for SqlMigrationPersistence {
     }
 
     async fn update(&self, params: &MigrationUpdateParams) -> Result<(), ConnectorError> {
-        self.catch(async {
+        crate::catch(self.connection_info(), async {
             let finished_at_value = match params.finished_at {
                 Some(x) => self.convert_datetime(x),
                 None => ParameterizedValue::Null,
@@ -195,7 +185,7 @@ impl MigrationPersistence for SqlMigrationPersistence {
                         .and(REVISION_COLUMN.equals(params.revision)),
                 );
 
-            self.connection.query(query.into()).await?;
+            self.conn().query(query.into()).await?;
 
             Ok(())
         })
@@ -233,19 +223,19 @@ fn migration_table_setup(
     t.add_column(FINISHED_AT_COLUMN, datetime_type.clone().nullable(true));
 }
 
-impl SqlMigrationPersistence {
+impl<'a> SqlMigrationPersistence<'a> {
     fn table(&self) -> Table {
-        match self.connection_info.sql_family() {
+        match self.sql_family() {
             SqlFamily::Sqlite => {
                 // sqlite case. Otherwise quaint produces invalid SQL
                 TABLE_NAME.to_string().into()
             }
-            _ => (self.schema_name.to_string(), TABLE_NAME.to_string()).into(),
+            _ => (self.schema_name().to_string(), TABLE_NAME.to_string()).into(),
         }
     }
 
     fn convert_datetime(&self, datetime: DateTime<Utc>) -> ParameterizedValue {
-        match self.connection_info.sql_family() {
+        match self.sql_family() {
             SqlFamily::Sqlite => ParameterizedValue::Integer(datetime.timestamp_millis()),
             SqlFamily::Postgres => ParameterizedValue::DateTime(datetime),
             SqlFamily::Mysql => ParameterizedValue::DateTime(datetime),

--- a/migration-engine/core/src/api.rs
+++ b/migration-engine/core/src/api.rs
@@ -7,7 +7,6 @@ pub use rpc::*;
 
 use crate::{commands::*, migration_engine::MigrationEngine, CoreResult};
 use migration_connector::*;
-use std::sync::Arc;
 use tracing_futures::Instrument;
 
 pub struct MigrationApi<C, D>
@@ -52,7 +51,7 @@ pub trait GenericApi: Send + Sync + 'static {
     async fn migration_progress(&self, input: &MigrationProgressInput) -> CoreResult<MigrationProgressOutput>;
     async fn reset(&self, input: &serde_json::Value) -> CoreResult<serde_json::Value>;
     async fn unapply_migration(&self, input: &UnapplyMigrationInput) -> CoreResult<UnapplyMigrationOutput>;
-    fn migration_persistence(&self) -> Arc<dyn MigrationPersistence>;
+    fn migration_persistence<'a>(&'a self) -> Box<dyn MigrationPersistence + 'a>;
     fn connector_type(&self) -> &'static str;
 
     fn render_error(&self, error: crate::error::Error) -> user_facing_errors::Error {
@@ -130,7 +129,7 @@ where
             .await
     }
 
-    fn migration_persistence(&self) -> Arc<dyn MigrationPersistence> {
+    fn migration_persistence<'a>(&'a self) -> Box<dyn MigrationPersistence + 'a> {
         self.engine.connector().migration_persistence()
     }
 


### PR DESCRIPTION
This allows us to keep a reference to the connector inside each of them,
eliminating a bunch of boilerplate in the process. We also don't need
Arcs anymore.

The only constraint this imposes is that we do not drop the destructive
change checker after the connector, which would not make sense anyway.

This commit also introduces the Component trait in
SqlMigrationConnector, for code reuse and consistency across the crate.