### PR TITLE
Explore less destructive alter column

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3042,7 +3042,7 @@ name = "twox-hash"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/introspection-engine/connectors/sql-introspection-connector/Cargo.toml
+++ b/introspection-engine/connectors/sql-introspection-connector/Cargo.toml
@@ -16,7 +16,7 @@ failure = "0.1"
 log = "0.4"
 regex = "1.2"
 url = "1.7"
-user-facing-errors = { path = "../../../libs/user-facing-errors" }
+user-facing-errors = { path = "../../../libs/user-facing-errors", features = ["sql"] }
 tracing = "0.1.10"
 tracing-futures = "0.2.0"
 tokio = { version = "0.2", features = ["rt-threaded", "time"] }

--- a/libs/sql-schema-describer/src/lib.rs
+++ b/libs/sql-schema-describer/src/lib.rs
@@ -304,6 +304,15 @@ pub enum ColumnArity {
     List,
 }
 
+impl ColumnArity {
+    pub fn is_required(&self) -> bool {
+        match self {
+            ColumnArity::Required => true,
+            _ => false,
+        }
+    }
+}
+
 /// Foreign key action types (for ON DELETE|ON UPDATE).
 #[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/libs/user-facing-errors/Cargo.toml
+++ b/libs/user-facing-errors/Cargo.toml
@@ -13,4 +13,8 @@ serde = { version = "1.0.102", features = ["derive"] }
 backtrace = "0.3.40"
 failure = "*"
 log = "0.4.8"
-quaint = { version = "0.1", features = ["mysql", "postgresql", "sqlite"] }
+quaint = { version = "0.1", features = ["mysql", "postgresql", "sqlite"], optional = true }
+
+[features]
+default = []
+sql = ["quaint"]

--- a/libs/user-facing-errors/src/lib.rs
+++ b/libs/user-facing-errors/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod common;
 pub mod introspection_engine;
 pub mod migration_engine;
+#[cfg(feature = "sql")]
 pub mod quaint;
 pub mod query_engine;
 

--- a/migration-engine/connectors/migration-connector/src/destructive_changes_checker.rs
+++ b/migration-engine/connectors/migration-connector/src/destructive_changes_checker.rs
@@ -46,7 +46,7 @@ impl DestructiveChangeDiagnostics {
 
 /// A warning emitted by [DestructiveChangesChecker](trait.DestructiveChangesChecker.html). Warnings will
 /// prevent a migration from being applied, unless the `force` flag is passed.
-#[derive(Debug, Serialize, PartialEq)]
+#[derive(Debug, Serialize, PartialEq, Clone)]
 pub struct MigrationWarning {
     pub description: String,
 }

--- a/migration-engine/connectors/sql-migration-connector/Cargo.toml
+++ b/migration-engine/connectors/sql-migration-connector/Cargo.toml
@@ -21,4 +21,4 @@ thiserror = "1.0.9"
 tokio = { version = "0.2", features = ["time"] }
 tracing = "0.1.10"
 tracing-futures = "0.2.0"
-user-facing-errors = { path = "../../../libs/user-facing-errors" }
+user-facing-errors = { path = "../../../libs/user-facing-errors", features = ["sql"] }

--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -110,7 +110,6 @@ impl SqlMigrationConnector {
     }
 
     async fn initialize_impl(&self) -> SqlResult<()> {
-        // TODO: this code probably does not ever do anything. The schema/db creation happens already in the helper functions above.
         match self.database_info.connection_info() {
             ConnectionInfo::Sqlite { file_path, .. } => {
                 let path_buf = PathBuf::from(&file_path);

--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -279,6 +279,10 @@ fn render_raw_sql(
                             let constraint_name = renderer.quote(&constraint_name);
                             lines.push(format!("DROP FOREIGN KEY {}", constraint_name));
                         }
+                        SqlFamily::Postgres => {
+                            let constraint_name = renderer.quote(&constraint_name);
+                            lines.push(format!("DROP CONSTRAINT IF EXiSTS {}", constraint_name));
+                        }
                         _ => (),
                     },
                 };
@@ -435,6 +439,11 @@ fn safe_alter_column(
                     format!("{} SET DEFAULT '{}'", &alter_column_prefix, new_default)
                 }
                 PostgresAlterColumn::DropNotNull => format!("{} DROP NOT NULL", &alter_column_prefix),
+                PostgresAlterColumn::SetType(ty) => format!(
+                    "{} SET DATA TYPE {}",
+                    &alter_column_prefix,
+                    renderer.render_column_type(&ty)
+                ),
             })
             .collect(),
         ExpandedAlterColumn::Mysql(steps) => steps

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker.rs
@@ -175,13 +175,14 @@ impl SqlDestructiveChangesChecker<'_> {
 
                 // We keep the match here to keep the exhaustiveness checking for when we add variants.
                 if let Some(steps) = expanded {
-                    let is_safe = true;
+                    let mut is_safe = true;
 
                     for step in steps {
                         match step {
                             PostgresAlterColumn::SetDefault(_)
                             | PostgresAlterColumn::DropDefault
                             | PostgresAlterColumn::DropNotNull => (),
+                            PostgresAlterColumn::SetType(_) => is_safe = false,
                         }
                     }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker.rs
@@ -3,7 +3,7 @@ use crate::{
     TableChange,
 };
 use migration_connector::*;
-use quaint::ast::*;
+use quaint::{ast::*, prelude::SqlFamily};
 use sql_schema_describer::{ColumnArity, SqlSchema};
 
 pub struct SqlDestructiveChangesChecker<'a> {
@@ -146,22 +146,69 @@ impl SqlDestructiveChangesChecker<'_> {
     /// - default changes on SQLite
     /// - Arity changes from required to optional on SQLite
     fn alter_column_is_safe(&self, alter_column: &AlterColumn, previous_column: &sql_schema_describer::Column) -> bool {
-        if !self.sql_family().is_sqlite() {
-            return false;
-        }
+        use crate::sql_migration::expanded_alter_column::*;
 
-        let arity_change_is_safe = match (&previous_column.tpe.arity, &alter_column.column.tpe.arity) {
-            // column became required
-            (ColumnArity::Nullable, ColumnArity::Required) => false,
-            // column became nullable
-            (ColumnArity::Required, ColumnArity::Nullable) => true,
-            // nothing changed
-            (ColumnArity::Required, ColumnArity::Required) | (ColumnArity::Nullable, ColumnArity::Nullable) => true,
-            // not supported on SQLite
-            (ColumnArity::List, _) | (_, ColumnArity::List) => unreachable!(),
+        let differ = crate::sql_schema_differ::ColumnDiffer {
+            previous: previous_column,
+            next: &alter_column.column,
         };
 
-        alter_column.column.tpe.family == previous_column.tpe.family && arity_change_is_safe
+        match self.sql_family() {
+            SqlFamily::Sqlite => {
+                let arity_change_is_safe = match (&previous_column.tpe.arity, &alter_column.column.tpe.arity) {
+                    // column became required
+                    (ColumnArity::Nullable, ColumnArity::Required) => false,
+                    // column became nullable
+                    (ColumnArity::Required, ColumnArity::Nullable) => true,
+                    // nothing changed
+                    (ColumnArity::Required, ColumnArity::Required) | (ColumnArity::Nullable, ColumnArity::Nullable) => {
+                        true
+                    }
+                    // not supported on SQLite
+                    (ColumnArity::List, _) | (_, ColumnArity::List) => unreachable!(),
+                };
+
+                !differ.all_changes().type_changed() && arity_change_is_safe
+            }
+            SqlFamily::Postgres => {
+                let expanded = expand_postgres_alter_column(differ);
+
+                // We keep the match here to keep the exhaustiveness checking for when we add variants.
+                if let Some(steps) = expanded {
+                    let is_safe = true;
+
+                    for step in steps {
+                        match step {
+                            PostgresAlterColumn::SetDefault(_)
+                            | PostgresAlterColumn::DropDefault
+                            | PostgresAlterColumn::DropNotNull => (),
+                        }
+                    }
+
+                    is_safe
+                } else {
+                    false
+                }
+            }
+            SqlFamily::Mysql => {
+                let expanded = expand_mysql_alter_column(differ);
+
+                // We keep the match here to keep the exhaustiveness checking for when we add variants.
+                if let Some(steps) = expanded {
+                    let is_safe = true;
+
+                    for step in steps {
+                        match step {
+                            MysqlAlterColumn::SetDefault(_) | MysqlAlterColumn::DropDefault => (),
+                        }
+                    }
+
+                    is_safe
+                } else {
+                    false
+                }
+            }
+        }
     }
 
     async fn check_impl(

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
@@ -1,6 +1,8 @@
+pub(crate) mod expanded_alter_column;
+
 use migration_connector::DatabaseMigrationMarker;
 use serde::{Deserialize, Serialize};
-use sql_schema_describer::*;
+use sql_schema_describer::{Column, ForeignKey, Index, SqlSchema, Table};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SqlMigration {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration/expanded_alter_column.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration/expanded_alter_column.rs
@@ -1,0 +1,94 @@
+use crate::sql_schema_differ::{ColumnChange, ColumnDiffer};
+use quaint::prelude::SqlFamily;
+use sql_schema_describer::{Column, ColumnArity};
+
+pub(crate) fn expand_alter_column(
+    previous_column: &Column,
+    next_column: &Column,
+    sql_family: &SqlFamily,
+) -> Option<ExpandedAlterColumn> {
+    let column_differ = ColumnDiffer {
+        previous: previous_column,
+        next: next_column,
+    };
+
+    match sql_family {
+        SqlFamily::Sqlite => expand_sqlite_alter_column(column_differ).map(ExpandedAlterColumn::Sqlite),
+        SqlFamily::Mysql => expand_mysql_alter_column(column_differ).map(ExpandedAlterColumn::Mysql),
+        SqlFamily::Postgres => expand_postgres_alter_column(column_differ).map(ExpandedAlterColumn::Postgres),
+    }
+}
+
+pub(crate) fn expand_sqlite_alter_column(_columns: ColumnDiffer) -> Option<Vec<SqliteAlterColumn>> {
+    None
+}
+
+pub(crate) fn expand_mysql_alter_column(columns: ColumnDiffer) -> Option<Vec<MysqlAlterColumn>> {
+    let mut changes: Vec<MysqlAlterColumn> = Vec::new();
+
+    for change in columns.all_changes().iter() {
+        match change {
+            ColumnChange::Default => match (&columns.previous.default, &columns.next.default) {
+                (_, Some(next_default)) => changes.push(MysqlAlterColumn::SetDefault(next_default.clone())),
+                (_, None) => changes.push(MysqlAlterColumn::DropDefault),
+            },
+            _ => return None,
+        }
+    }
+
+    Some(changes)
+}
+
+pub(crate) fn expand_postgres_alter_column(columns: ColumnDiffer) -> Option<Vec<PostgresAlterColumn>> {
+    let mut changes = Vec::new();
+
+    for change in columns.all_changes().iter() {
+        match change {
+            ColumnChange::Default => match (&columns.previous.default, &columns.next.default) {
+                (_, Some(next_default)) => changes.push(PostgresAlterColumn::SetDefault(next_default.clone())),
+                (_, None) => changes.push(PostgresAlterColumn::DropDefault),
+            },
+            ColumnChange::Arity => match (&columns.previous.tpe.arity, &columns.next.tpe.arity) {
+                (ColumnArity::Required, ColumnArity::Nullable) => changes.push(PostgresAlterColumn::DropNotNull),
+                _ => return None,
+            },
+            _ => return None,
+        }
+    }
+
+    Some(changes)
+}
+
+#[derive(Debug)]
+pub(crate) enum ExpandedAlterColumn {
+    Postgres(Vec<PostgresAlterColumn>),
+    Mysql(Vec<MysqlAlterColumn>),
+    Sqlite(Vec<SqliteAlterColumn>),
+}
+
+#[derive(Debug)]
+/// https://www.postgresql.org/docs/9.1/sql-altertable.html
+pub(crate) enum PostgresAlterColumn {
+    SetDefault(String),
+    DropDefault,
+    DropNotNull,
+    // Not used yet:
+    // SetNotNull,
+    // Rename { previous_name: String, next_name: String },
+    // SetType(String),
+}
+
+/// https://dev.mysql.com/doc/refman/8.0/en/alter-table.html
+#[derive(Debug)]
+pub(crate) enum MysqlAlterColumn {
+    SetDefault(String),
+    DropDefault,
+    // Not used yet:
+    // Rename { previous_name: String, next_name: String },
+}
+
+#[derive(Debug)]
+pub(crate) enum SqliteAlterColumn {
+    // Not used yet:
+// Rename { previous_name: String, next_name: String },
+}

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/common.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/common.rs
@@ -35,23 +35,3 @@ pub fn render_on_delete(on_delete: &ForeignKeyAction) -> &'static str {
         ForeignKeyAction::Restrict => "ON DELETE RESTRICT",
     }
 }
-
-// TODO: this returns None for expressions
-// TODO: bring back once values for columns are not untyped Strings anymore
-//fn render_value(value: &Value) -> Option<String> {
-//    match value {
-//        Value::Boolean(x) => Some(if *x { "true".to_string() } else { "false".to_string() }),
-//        Value::Int(x) => Some(format!("{}", x)),
-//        Value::Float(x) => Some(format!("{}", x)),
-//        Value::Decimal(x) => Some(format!("{}", x)),
-//        Value::String(x) => Some(format!("'{}'", x)),
-//
-//        Value::DateTime(x) => {
-//            let mut raw = format!("{}", x); // this will produce a String 1970-01-01 00:00:00 UTC
-//            raw.truncate(raw.len() - 4); // strip the UTC suffix
-//            Some(format!("'{}'", raw)) // add quotes
-//        }
-//        Value::ConstantLiteral(x) => Some(format!("'{}'", x)), // this represents enum values
-//        _ => None,
-//    }
-//}

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
@@ -1,3 +1,5 @@
+pub(crate) use column::{ColumnChange, ColumnDiffer};
+
 mod column;
 mod index;
 mod table;

--- a/migration-engine/core/src/tests/migration_tests.rs
+++ b/migration-engine/core/src/tests/migration_tests.rs
@@ -293,52 +293,59 @@ async fn updating_db_name_of_a_scalar_field_must_work(api: &TestApi) {
     assert_eq!(result.table_bang("A").column("name2").is_some(), true);
 }
 
-// this relies on link: INLINE which we don't support yet
-#[test_each_connector(ignore = "mysql")]
-async fn changing_a_relation_field_to_a_scalar_field_must_work(api: &TestApi) {
+#[test_each_connector(log = "debug")]
+async fn changing_a_relation_field_to_a_scalar_field_must_work(api: &TestApi) -> TestResult {
     let dm1 = r#"
-            model A {
-                id Int @id
-                b B @relation(references: [id])
-            }
-            model B {
-                id Int @id
-                a A // remove this once the implicit back relation field is implemented
-            }
-        "#;
-    let result = api.infer_and_apply(&dm1).await.sql_schema;
-    let table = result.table_bang("A");
-    let column = table.column_bang("b");
-    assert_eq!(column.tpe.family, ColumnTypeFamily::Int);
-    assert_eq!(
-        table.foreign_keys,
-        &[ForeignKey {
-            constraint_name: match api.sql_family() {
-                SqlFamily::Postgres => Some("A_b_fkey".to_owned()),
-                SqlFamily::Mysql => Some("A_ibfk_1".to_owned()),
-                SqlFamily::Sqlite => None,
-            },
-            columns: vec![column.name.clone()],
-            referenced_table: "B".to_string(),
-            referenced_columns: vec!["id".to_string()],
-            on_delete_action: ForeignKeyAction::Restrict,
-        }]
-    );
+        model A {
+            id Int @id
+            b B @relation(references: [id])
+        }
+        model B {
+            id Int @id
+            a A // remove this once the implicit back relation field is implemented
+        }
+    "#;
+
+    api.infer_apply(dm1).send().await?;
+    api.assert_schema().await?.assert_table("A", |table| {
+        table
+            .assert_column("b", |col| col.assert_type_is_int())?
+            .assert_foreign_keys_count(1)?
+            .assert_has_fk(&ForeignKey {
+                constraint_name: match api.sql_family() {
+                    SqlFamily::Postgres => Some("A_b_fkey".to_owned()),
+                    SqlFamily::Mysql => Some("A_ibfk_1".to_owned()),
+                    SqlFamily::Sqlite => None,
+                },
+                columns: vec!["b".to_owned()],
+                referenced_table: "B".to_string(),
+                referenced_columns: vec!["id".to_string()],
+                on_delete_action: ForeignKeyAction::Restrict,
+            })
+    })?;
 
     let dm2 = r#"
-            model A {
-                id Int @id
-                b String
-            }
-            model B {
-                id Int @id
-            }
-        "#;
-    let result = api.infer_and_apply(&dm2).await.sql_schema;
-    let table = result.table_bang("A");
+        model A {
+            id Int @id
+            b String
+        }
+        model B {
+            id Int @id
+        }
+    "#;
+
+    let result = api.infer_apply(dm2).send().await?;
+
+    anyhow::ensure!(result.warnings.is_empty(), "Warnings should be empty");
+
+    let schema = api.assert_schema().await?.into_schema();
+
+    let table = schema.table_bang("A");
     let column = table.column_bang("b");
     assert_eq!(column.tpe.family, ColumnTypeFamily::String);
     assert_eq!(table.foreign_keys, vec![]);
+
+    Ok(())
 }
 
 #[test_each_connector]

--- a/migration-engine/core/src/tests/test_harness/assertions.rs
+++ b/migration-engine/core/src/tests/test_harness/assertions.rs
@@ -158,7 +158,14 @@ pub struct ColumnAssertion<'a>(&'a Column);
 
 impl<'a> ColumnAssertion<'a> {
     pub fn assert_default(self, expected: Option<&str>) -> AssertionResult<Self> {
-        assert_eq!(self.0.default.as_ref().map(String::as_str), expected);
+        let found = self.0.default.as_ref().map(String::as_str);
+
+        anyhow::ensure!(
+            found == expected,
+            "Assertion failed. Expected default: {:?}, but found {:?}",
+            expected,
+            found
+        );
 
         Ok(self)
     }

--- a/migration-engine/core/src/tests/test_harness/assertions.rs
+++ b/migration-engine/core/src/tests/test_harness/assertions.rs
@@ -182,6 +182,18 @@ impl<'a> ColumnAssertion<'a> {
         Ok(self)
     }
 
+    pub fn assert_type_is_int(self) -> AssertionResult<Self> {
+        let found = &self.0.tpe.family;
+
+        anyhow::ensure!(
+            found == &sql_schema_describer::ColumnTypeFamily::Int,
+            "Assertion failed. Expected an integer column, got {:?}.",
+            found
+        );
+
+        Ok(self)
+    }
+
     pub fn assert_is_required(self) -> AssertionResult<Self> {
         anyhow::ensure!(
             self.0.tpe.arity.is_required(),

--- a/migration-engine/core/src/tests/test_harness/assertions.rs
+++ b/migration-engine/core/src/tests/test_harness/assertions.rs
@@ -70,6 +70,14 @@ impl<'a> TableAssertion<'a> {
         Ok(self)
     }
 
+    pub fn assert_has_fk(self, fk: &ForeignKey) -> AssertionResult<Self> {
+        let matching_fk = self.0.foreign_keys.iter().any(|found| found == fk);
+
+        anyhow::ensure!(matching_fk, "Assertion failed. Could not find fk.");
+
+        Ok(self)
+    }
+
     pub fn assert_fk_on_columns<F>(self, columns: &[&str], fk_assertions: F) -> AssertionResult<Self>
     where
         F: FnOnce(ForeignKeyAssertion<'a>) -> AssertionResult<ForeignKeyAssertion<'a>>,

--- a/migration-engine/core/src/tests/test_harness/assertions.rs
+++ b/migration-engine/core/src/tests/test_harness/assertions.rs
@@ -169,6 +169,29 @@ impl<'a> ColumnAssertion<'a> {
 
         Ok(self)
     }
+
+    pub fn assert_type_is_string(self) -> AssertionResult<Self> {
+        let found = &self.0.tpe.family;
+
+        anyhow::ensure!(
+            found == &sql_schema_describer::ColumnTypeFamily::String,
+            "Assertion failed. Expected a string column, got {:?}.",
+            found
+        );
+
+        Ok(self)
+    }
+
+    pub fn assert_is_required(self) -> AssertionResult<Self> {
+        anyhow::ensure!(
+            self.0.tpe.arity.is_required(),
+            "Assertion failed. Expected column `{}` to be NOT NULL, got {:?}",
+            self.0.name,
+            self.0.tpe.arity,
+        );
+
+        Ok(self)
+    }
 }
 
 pub struct PrimaryKeyAssertion<'a>(&'a PrimaryKey);

--- a/migration-engine/core/src/tests/test_harness/mod.rs
+++ b/migration-engine/core/src/tests/test_harness/mod.rs
@@ -3,6 +3,7 @@
 mod assertions;
 mod command_helpers;
 mod misc_helpers;
+pub(super) mod sql;
 mod step_helpers;
 mod test_api;
 

--- a/migration-engine/core/src/tests/test_harness/sql.rs
+++ b/migration-engine/core/src/tests/test_harness/sql.rs
@@ -1,0 +1,7 @@
+pub use super::assertions::*;
+pub use super::command_helpers::*;
+pub use super::misc_helpers::*;
+pub use super::step_helpers::*;
+pub use super::test_api::*;
+pub use test_macros::*;
+pub use test_setup::*;

--- a/migration-engine/core/src/tests/test_harness/test_api.rs
+++ b/migration-engine/core/src/tests/test_harness/test_api.rs
@@ -67,7 +67,7 @@ impl TestApi {
     }
 
     /// Render a table name with the required prefixing for use with quaint query building.
-    pub fn render_table_name(&self, table_name: &str) -> quaint::ast::Table {
+    pub fn render_table_name<'a>(&self, table_name: &'a str) -> quaint::ast::Table<'a> {
         (self.schema_name().to_owned(), table_name.to_owned()).into()
     }
 
@@ -189,6 +189,10 @@ impl TestApi {
             quaint::ast::Select::from_table(self.render_table_name(table_name)).value(quaint::ast::asterisk());
 
         self.database.query(select_star.into()).await
+    }
+
+    pub fn insert<'a>(&self, table_name: &'a str) -> quaint::ast::SingleRowInsert<'a> {
+        quaint::ast::Insert::single_into(self.render_table_name(table_name))
     }
 }
 

--- a/query-engine/connectors/sql-query-connector/Cargo.toml
+++ b/query-engine/connectors/sql-query-connector/Cargo.toml
@@ -45,3 +45,4 @@ git = "https://github.com/prisma/cuid-rust"
 
 [dependencies.user-facing-errors]
 path = "../../../libs/user-facing-errors"
+features = ["sql"]


### PR DESCRIPTION
- Default migrations (add/change/remove default) are now non-destructive
- Migrating a column from required to optional is now non-destructive