### PR TITLE
Implement starts_with in test-macros

### DIFF
--- a/libs/test-macros/src/lib.rs
+++ b/libs/test-macros/src/lib.rs
@@ -31,6 +31,10 @@ struct TestEachConnectorArgs {
     /// Comma-separated list of connectors to exclude.
     #[darling(default)]
     ignore: Option<String>,
+
+    #[darling(default)]
+    starts_with: Option<String>,
+
     #[darling(default)]
     log: Option<String>,
 }
@@ -38,11 +42,18 @@ struct TestEachConnectorArgs {
 impl TestEachConnectorArgs {
     fn connectors_to_test(&self) -> impl Iterator<Item = &&str> {
         let ignore = self.ignore.as_ref().map(String::as_str);
+        let starts_with = self.starts_with.as_ref().map(String::as_str);
 
-        CONNECTOR_NAMES.iter().filter(move |connector_name| match ignore {
-            Some(ignore) => !connector_name.starts_with(&ignore),
-            None => true,
-        })
+        CONNECTOR_NAMES
+            .iter()
+            .filter(move |connector_name| match ignore {
+                Some(ignore) => !connector_name.starts_with(&ignore),
+                None => true,
+            })
+            .filter(move |connector_name| match starts_with {
+                Some(pat) => connector_name.starts_with(pat),
+                None => true,
+            })
     }
 }
 


### PR DESCRIPTION
The intent is to replace `test_one_connector` with a more general
`test_each_connector` eventually.