### PR TITLE
Optionally validate assumeToBeApplied migrations in CalculateDatabaseSteps

### DIFF
--- a/migration-engine/core/src/commands/calculate_database_steps.rs
+++ b/migration-engine/core/src/commands/calculate_database_steps.rs
@@ -1,6 +1,10 @@
 //! The CalculateDatabaseSteps RPC method.
+//!
+//! Its purpose is to infer the database steps for a given migration without reference to a target
+//! prisma schema/datamodel, based on the datamodel migration steps and previous already applied
+//! migrations.
 
-use super::MigrationStepsResultOutput;
+use super::{AppliedMigration, MigrationStepsResultOutput};
 use crate::commands::command::*;
 use crate::migration_engine::MigrationEngine;
 use datamodel::ast::SchemaAst;
@@ -26,10 +30,15 @@ impl<'a> MigrationCommand for CalculateDatabaseStepsCommand<'a> {
         debug!(command_input = ?cmd.input);
 
         let connector = engine.connector();
+        let migration_persistence = connector.migration_persistence();
+
+        let assume_to_be_applied = cmd.assume_to_be_applied();
+        cmd.validate_assumed_migrations_are_not_applied(migration_persistence.as_ref())
+            .await?;
 
         let assumed_datamodel_ast = engine
             .datamodel_calculator()
-            .infer(&SchemaAst::empty(), &cmd.input.assume_to_be_applied)?;
+            .infer(&SchemaAst::empty(), &assume_to_be_applied)?;
         let assumed_datamodel = datamodel::lift_ast(&assumed_datamodel_ast)?;
 
         let next_datamodel_ast = engine
@@ -67,9 +76,54 @@ impl<'a> MigrationCommand for CalculateDatabaseStepsCommand<'a> {
     }
 }
 
+impl CalculateDatabaseStepsCommand<'_> {
+    fn assume_to_be_applied(&self) -> Vec<MigrationStep> {
+        self.input
+            .assume_to_be_applied
+            .clone()
+            .or_else(|| {
+                self.input.assume_applied_migrations.as_ref().map(|migrations| {
+                    migrations
+                        .into_iter()
+                        .flat_map(|migration| migration.datamodel_steps.clone().into_iter())
+                        .collect()
+                })
+            })
+            .unwrap_or_else(Vec::new)
+    }
+
+    async fn validate_assumed_migrations_are_not_applied(
+        &self,
+        migration_persistence: &dyn MigrationPersistence,
+    ) -> CommandResult<()> {
+        if let Some(migrations) = self.input.assume_applied_migrations.as_ref() {
+            for migration in migrations {
+                if migration_persistence
+                    .migration_is_already_applied(&migration.migration_id)
+                    .await?
+                {
+                    return Err(CommandError::ConnectorError(ConnectorError {
+                        user_facing_error: None,
+                        kind: ErrorKind::Generic(anyhow::anyhow!(
+                            "Input is invalid. Migration {} is already applied.",
+                            migration.migration_id
+                        )),
+                    }));
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct CalculateDatabaseStepsInput {
-    pub assume_to_be_applied: Vec<MigrationStep>,
     pub steps_to_apply: Vec<MigrationStep>,
+    /// Migration steps from migrations that have been inferred but not applied yet.
+    ///
+    /// These steps must be provided and correct for migration inferrence to work.
+    pub assume_to_be_applied: Option<Vec<MigrationStep>>,
+    pub assume_applied_migrations: Option<Vec<AppliedMigration>>,
 }

--- a/migration-engine/core/src/tests/calculate_database_steps_tests.rs
+++ b/migration-engine/core/src/tests/calculate_database_steps_tests.rs
@@ -1,0 +1,114 @@
+use crate::commands::AppliedMigration;
+use crate::tests::test_harness::sql::*;
+
+#[test_each_connector]
+async fn calculate_database_steps_with_infer_after_an_apply_must_work(api: &TestApi) -> TestResult {
+    let dm1 = r#"
+        type CUID = String @id @default(cuid())
+
+        model User {
+            id CUID
+        }
+    "#;
+
+    let output = api
+        .infer(dm1)
+        .assume_to_be_applied(Some(Vec::new()))
+        .migration_id(Some("mig02"))
+        .send()
+        .await?;
+
+    let steps = output.datamodel_steps;
+
+    api.infer_apply(dm1).send_assert().await?.assert_green()?;
+
+    let dm2 = r#"
+        type CUID = String @id @default(cuid())
+
+        model User {
+            id CUID
+            name String
+        }
+
+        model Cat {
+            id CUID
+            age Int
+        }
+    "#;
+
+    let output = api
+        .infer(dm2)
+        .assume_to_be_applied(Some(Vec::new()))
+        .migration_id(Some("mig02"))
+        .send()
+        .await?;
+
+    let new_steps = output.datamodel_steps.clone();
+
+    let result = api
+        .calculate_database_steps()
+        .assume_to_be_applied(Some(steps))
+        .steps_to_apply(Some(new_steps.clone()))
+        .send()
+        .await?;
+
+    assert_eq!(result.datamodel_steps, new_steps);
+
+    Ok(())
+}
+
+#[test_each_connector]
+async fn calculate_database_steps_with_already_applied_steps_does_not_crash(api: &TestApi) -> TestResult {
+    let first_migration_id = "first-migration";
+
+    // Apply a first migration
+    let output = {
+        let dm1 = r#"
+            type CUID = String @id @default(cuid())
+    
+            model User {
+                id CUID
+            }
+        "#;
+
+        api.infer_apply(dm1)
+            .migration_id(Some(first_migration_id))
+            .send_assert()
+            .await?
+            .assert_green()?
+            .into_inner()
+    };
+
+    // Try calculating a second migration with bad assumeAppliedMigration
+    {
+        let dm2 = r#"
+            type CUID = String @id @default(cuid())
+
+            model User {
+                id CUID
+                name String @default("maggie smith")
+            }
+
+            model Cat {
+                id CUID
+                age Int
+            }
+        "#;
+
+        let inferred_steps = api.infer(dm2).send().await?;
+
+        let result = api
+            .calculate_database_steps()
+            .steps_to_apply(Some(inferred_steps.datamodel_steps))
+            .assume_applied_migrations(Some(vec![AppliedMigration {
+                datamodel_steps: output.datamodel_steps,
+                migration_id: first_migration_id.to_owned(),
+            }]))
+            .send()
+            .await;
+
+        assert_eq!(result.unwrap_err().to_string(), "Failure during a migration command: Connector error. (error: Input is invalid. Migration first-migration is already applied.)");
+    }
+
+    Ok(())
+}

--- a/migration-engine/core/src/tests/migration_tests.rs
+++ b/migration-engine/core/src/tests/migration_tests.rs
@@ -4,9 +4,6 @@ mod mysql;
 mod sqlite;
 
 use super::test_harness::*;
-use crate::commands::{
-    CalculateDatabaseStepsCommand, CalculateDatabaseStepsInput, InferMigrationStepsCommand, InferMigrationStepsInput,
-};
 use pretty_assertions::assert_eq;
 use quaint::prelude::SqlFamily;
 use sql_migration_connector::{AlterIndex, CreateIndex, DropIndex, SqlMigrationStep};
@@ -1424,67 +1421,6 @@ async fn foreign_keys_of_inline_one_to_one_relations_have_a_unique_constraint(ap
     }];
 
     assert_eq!(box_table.indices, expected_indexes);
-}
-
-#[test_each_connector]
-async fn calculate_database_steps_with_infer_after_an_apply_must_work(api: &TestApi) {
-    let dm1 = r#"
-        type CUID = String @id @default(cuid())
-
-        model User {
-            id CUID
-        }
-    "#;
-
-    let infer_input = InferMigrationStepsInput {
-        assume_to_be_applied: Some(Vec::new()),
-        assume_applied_migrations: None,
-        datamodel: dm1.to_owned(),
-        migration_id: "mig02".to_owned(),
-    };
-
-    let output = api
-        .execute_command::<InferMigrationStepsCommand>(&infer_input)
-        .await
-        .unwrap();
-    let steps = output.datamodel_steps;
-
-    api.infer_and_apply(dm1).await;
-
-    let dm2 = r#"
-        type CUID = String @id @default(cuid())
-
-        model User {
-            id CUID
-            name String
-        }
-    "#;
-
-    let infer_input = InferMigrationStepsInput {
-        assume_to_be_applied: Some(Vec::new()),
-        assume_applied_migrations: None,
-        datamodel: dm2.to_owned(),
-        migration_id: "mig02".to_owned(),
-    };
-
-    let output = api
-        .execute_command::<InferMigrationStepsCommand>(&infer_input)
-        .await
-        .unwrap();
-
-    let new_steps = output.datamodel_steps.clone();
-
-    let calculate_input = CalculateDatabaseStepsInput {
-        assume_to_be_applied: steps,
-        steps_to_apply: new_steps.clone(),
-    };
-
-    let result = api
-        .execute_command::<CalculateDatabaseStepsCommand>(&calculate_input)
-        .await
-        .unwrap();
-
-    assert_eq!(result.datamodel_steps, new_steps);
 }
 
 #[test_each_connector]

--- a/migration-engine/core/src/tests/mod.rs
+++ b/migration-engine/core/src/tests/mod.rs
@@ -1,4 +1,5 @@
 mod apply_migration_tests;
+mod calculate_database_steps_tests;
 mod datamodel_calculator_tests;
 mod datamodel_steps_inferrer_tests;
 mod error_tests;

--- a/migration-engine/core/src/tests/test_harness/test_api.rs
+++ b/migration-engine/core/src/tests/test_harness/test_api.rs
@@ -1,9 +1,11 @@
 mod apply;
+mod calculate_database_steps;
 mod infer;
 mod infer_apply;
 mod unapply_migration;
 
 pub(crate) use apply::Apply;
+pub(crate) use calculate_database_steps::CalculateDatabaseSteps;
 pub(crate) use infer::Infer;
 pub(crate) use infer_apply::InferApply;
 pub(crate) use unapply_migration::UnapplyMigration;
@@ -197,6 +199,10 @@ impl TestApi {
             select: quaint::ast::Select::from_table(self.render_table_name(table_name)),
             api: self,
         }
+    }
+
+    pub(crate) fn calculate_database_steps<'a>(&'a self) -> CalculateDatabaseSteps<'a> {
+        CalculateDatabaseSteps::new(&self.api)
     }
 }
 

--- a/migration-engine/core/src/tests/test_harness/test_api/calculate_database_steps.rs
+++ b/migration-engine/core/src/tests/test_harness/test_api/calculate_database_steps.rs
@@ -1,0 +1,53 @@
+use crate::{
+    api::GenericApi,
+    commands::{AppliedMigration, CalculateDatabaseStepsInput, MigrationStepsResultOutput},
+};
+use migration_connector::MigrationStep;
+pub(crate) struct CalculateDatabaseSteps<'a> {
+    api: &'a dyn GenericApi,
+    assume_to_be_applied: Option<Vec<MigrationStep>>,
+    assume_applied_migrations: Option<Vec<AppliedMigration>>,
+    steps_to_apply: Option<Vec<MigrationStep>>,
+}
+
+impl<'a> CalculateDatabaseSteps<'a> {
+    pub(crate) fn new(api: &'a dyn GenericApi) -> Self {
+        CalculateDatabaseSteps {
+            api,
+            assume_applied_migrations: None,
+            assume_to_be_applied: None,
+            steps_to_apply: None,
+        }
+    }
+
+    pub(crate) fn assume_applied_migrations(
+        mut self,
+        assume_applied_migrations: Option<Vec<AppliedMigration>>,
+    ) -> Self {
+        self.assume_applied_migrations = assume_applied_migrations;
+
+        self
+    }
+
+    pub(crate) fn assume_to_be_applied(mut self, assume_to_be_applied: Option<Vec<MigrationStep>>) -> Self {
+        self.assume_to_be_applied = assume_to_be_applied;
+
+        self
+    }
+
+    pub(crate) fn steps_to_apply(mut self, steps_to_apply: Option<Vec<MigrationStep>>) -> Self {
+        self.steps_to_apply = steps_to_apply;
+
+        self
+    }
+
+    pub(crate) async fn send(self) -> anyhow::Result<MigrationStepsResultOutput> {
+        let input = CalculateDatabaseStepsInput {
+            assume_to_be_applied: self.assume_to_be_applied,
+            assume_applied_migrations: self.assume_applied_migrations,
+            steps_to_apply: self.steps_to_apply.unwrap_or_else(Vec::new),
+        };
+
+        Ok(self.api.calculate_database_steps(&input).await?)
+    }
+}


### PR DESCRIPTION
Validate that they are not already applied, because that would crash the DatamodelCalculator.