### PR TITLE
Defensively trim assumeToBeApplied in CalculateDatabaseSteps

### DIFF
--- a/migration-engine/core/src/commands/calculate_database_steps.rs
+++ b/migration-engine/core/src/commands/calculate_database_steps.rs
@@ -4,7 +4,7 @@
 //! prisma schema/datamodel, based on the datamodel migration steps and previous already applied
 //! migrations.
 
-use super::{AppliedMigration, MigrationStepsResultOutput};
+use super::MigrationStepsResultOutput;
 use crate::commands::command::*;
 use crate::migration_engine::MigrationEngine;
 use datamodel::ast::SchemaAst;
@@ -30,11 +30,9 @@ impl<'a> MigrationCommand for CalculateDatabaseStepsCommand<'a> {
         debug!(command_input = ?cmd.input);
 
         let connector = engine.connector();
-        let migration_persistence = connector.migration_persistence();
 
-        let assume_to_be_applied = cmd.assume_to_be_applied();
-        cmd.validate_assumed_migrations_are_not_applied(migration_persistence.as_ref())
-            .await?;
+        let steps_to_apply = &cmd.input.steps_to_apply;
+        let assume_to_be_applied = cmd.applicable_steps();
 
         let assumed_datamodel_ast = engine
             .datamodel_calculator()
@@ -43,12 +41,12 @@ impl<'a> MigrationCommand for CalculateDatabaseStepsCommand<'a> {
 
         let next_datamodel_ast = engine
             .datamodel_calculator()
-            .infer(&assumed_datamodel_ast, &cmd.input.steps_to_apply)?;
+            .infer(&assumed_datamodel_ast, &steps_to_apply)?;
         let next_datamodel = datamodel::lift_ast(&next_datamodel_ast)?;
 
         let database_migration = connector
             .database_migration_inferrer()
-            .infer(&assumed_datamodel, &next_datamodel, &cmd.input.steps_to_apply)
+            .infer(&assumed_datamodel, &next_datamodel, &steps_to_apply)
             .await?;
 
         let DestructiveChangeDiagnostics {
@@ -66,7 +64,7 @@ impl<'a> MigrationCommand for CalculateDatabaseStepsCommand<'a> {
 
         Ok(MigrationStepsResultOutput {
             datamodel: datamodel::render_schema_ast_to_string(&next_datamodel_ast).unwrap(),
-            datamodel_steps: cmd.input.steps_to_apply.clone(),
+            datamodel_steps: steps_to_apply.to_vec(),
             database_steps: serde_json::Value::Array(database_steps_json),
             errors: Vec::new(),
             warnings,
@@ -77,43 +75,28 @@ impl<'a> MigrationCommand for CalculateDatabaseStepsCommand<'a> {
 }
 
 impl CalculateDatabaseStepsCommand<'_> {
-    fn assume_to_be_applied(&self) -> Vec<MigrationStep> {
-        self.input
-            .assume_to_be_applied
-            .clone()
-            .or_else(|| {
-                self.input.assume_applied_migrations.as_ref().map(|migrations| {
-                    migrations
-                        .into_iter()
-                        .flat_map(|migration| migration.datamodel_steps.clone().into_iter())
-                        .collect()
-                })
-            })
-            .unwrap_or_else(Vec::new)
-    }
+    /// Returns assume_to_be_applied from the input, with the exception of the steps from
+    /// steps_to_apply that may have been sent by mistake.
+    fn applicable_steps(&self) -> &[MigrationStep] {
+        match self.input.assume_to_be_applied.as_ref() {
+            Some(all_steps) => {
+                let steps_to_apply = &self.input.steps_to_apply;
 
-    async fn validate_assumed_migrations_are_not_applied(
-        &self,
-        migration_persistence: &dyn MigrationPersistence,
-    ) -> CommandResult<()> {
-        if let Some(migrations) = self.input.assume_applied_migrations.as_ref() {
-            for migration in migrations {
-                if migration_persistence
-                    .migration_is_already_applied(&migration.migration_id)
-                    .await?
-                {
-                    return Err(CommandError::ConnectorError(ConnectorError {
-                        user_facing_error: None,
-                        kind: ErrorKind::Generic(anyhow::anyhow!(
-                            "Input is invalid. Migration {} is already applied.",
-                            migration.migration_id
-                        )),
-                    }));
+                if steps_to_apply.len() >= all_steps.len() {
+                    return steps_to_apply;
                 }
-            }
-        }
 
-        Ok(())
+                let start_idx = all_steps.len() - (steps_to_apply.len());
+                let sliced = &all_steps[start_idx..];
+
+                if sliced == steps_to_apply.as_slice() {
+                    return &all_steps[..start_idx];
+                }
+
+                all_steps
+            }
+            None => return &[],
+        }
     }
 }
 
@@ -121,9 +104,5 @@ impl CalculateDatabaseStepsCommand<'_> {
 #[serde(rename_all = "camelCase")]
 pub struct CalculateDatabaseStepsInput {
     pub steps_to_apply: Vec<MigrationStep>,
-    /// Migration steps from migrations that have been inferred but not applied yet.
-    ///
-    /// These steps must be provided and correct for migration inferrence to work.
     pub assume_to_be_applied: Option<Vec<MigrationStep>>,
-    pub assume_applied_migrations: Option<Vec<AppliedMigration>>,
 }

--- a/migration-engine/core/src/tests/test_harness/test_api/calculate_database_steps.rs
+++ b/migration-engine/core/src/tests/test_harness/test_api/calculate_database_steps.rs
@@ -1,12 +1,11 @@
 use crate::{
     api::GenericApi,
-    commands::{AppliedMigration, CalculateDatabaseStepsInput, MigrationStepsResultOutput},
+    commands::{CalculateDatabaseStepsInput, MigrationStepsResultOutput},
 };
 use migration_connector::MigrationStep;
 pub(crate) struct CalculateDatabaseSteps<'a> {
     api: &'a dyn GenericApi,
     assume_to_be_applied: Option<Vec<MigrationStep>>,
-    assume_applied_migrations: Option<Vec<AppliedMigration>>,
     steps_to_apply: Option<Vec<MigrationStep>>,
 }
 
@@ -14,19 +13,9 @@ impl<'a> CalculateDatabaseSteps<'a> {
     pub(crate) fn new(api: &'a dyn GenericApi) -> Self {
         CalculateDatabaseSteps {
             api,
-            assume_applied_migrations: None,
             assume_to_be_applied: None,
             steps_to_apply: None,
         }
-    }
-
-    pub(crate) fn assume_applied_migrations(
-        mut self,
-        assume_applied_migrations: Option<Vec<AppliedMigration>>,
-    ) -> Self {
-        self.assume_applied_migrations = assume_applied_migrations;
-
-        self
     }
 
     pub(crate) fn assume_to_be_applied(mut self, assume_to_be_applied: Option<Vec<MigrationStep>>) -> Self {
@@ -44,10 +33,18 @@ impl<'a> CalculateDatabaseSteps<'a> {
     pub(crate) async fn send(self) -> anyhow::Result<MigrationStepsResultOutput> {
         let input = CalculateDatabaseStepsInput {
             assume_to_be_applied: self.assume_to_be_applied,
-            assume_applied_migrations: self.assume_applied_migrations,
             steps_to_apply: self.steps_to_apply.unwrap_or_else(Vec::new),
         };
 
         Ok(self.api.calculate_database_steps(&input).await?)
     }
+
+    pub(crate) async fn send_assert(self) -> anyhow::Result<CalculateDatabaseStepsAssertion<'a>> {
+        let api = self.api;
+        let result = self.send().await?;
+
+        Ok(super::infer_apply::InferApplyAssertion { api, result })
+    }
 }
+
+type CalculateDatabaseStepsAssertion<'a> = super::infer_apply::InferApplyAssertion<'a>;

--- a/migration-engine/core/src/tests/test_harness/test_api/infer_apply.rs
+++ b/migration-engine/core/src/tests/test_harness/test_api/infer_apply.rs
@@ -63,8 +63,8 @@ impl<'a> InferApply<'a> {
 }
 
 pub(crate) struct InferApplyAssertion<'a> {
-    result: MigrationStepsResultOutput,
-    api: &'a dyn GenericApi,
+    pub(super) result: MigrationStepsResultOutput,
+    pub(super) api: &'a dyn GenericApi,
 }
 
 impl<'a> InferApplyAssertion<'a> {


### PR DESCRIPTION
The migration steps in stepsToApply also being in assumeToBeApplied
would be consistent with some of the errors observed in the wild, so we
defensively trim them.