### PR TITLE
Fix relation fields in indexes in datamodel converter

### DIFF
--- a/libs/prisma-models/src/field.rs
+++ b/libs/prisma-models/src/field.rs
@@ -20,6 +20,30 @@ pub enum Field {
     Scalar(ScalarFieldRef),
 }
 
+impl Field {
+    pub fn downgrade(&self) -> FieldWeak {
+        match self {
+            Field::Relation(field) => FieldWeak::Relation(Arc::downgrade(field)),
+            Field::Scalar(field) => FieldWeak::Scalar(Arc::downgrade(field)),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum FieldWeak {
+    Relation(RelationFieldWeak),
+    Scalar(ScalarFieldWeak),
+}
+
+impl FieldWeak {
+    pub fn upgrade(&self) -> Field {
+        match self {
+            FieldWeak::Relation(field) => Field::Relation(field.upgrade().unwrap()),
+            FieldWeak::Scalar(field) => Field::Scalar(field.upgrade().unwrap()),
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct FieldManifestation {
     pub db_name: String,

--- a/libs/prisma-models/src/model.rs
+++ b/libs/prisma-models/src/model.rs
@@ -50,7 +50,7 @@ impl ModelTemplate {
             Arc::downgrade(&model),
         );
 
-        let indexes = self.indexes.into_iter().map(|i| i.build(&fields.scalar())).collect();
+        let indexes = self.indexes.into_iter().map(|i| i.build(&fields)).collect();
 
         // The model is created here and fields WILL BE UNSET before now!
         model.fields.set(fields).unwrap();

--- a/libs/prisma-models/tests/datamodel_converter_tests.rs
+++ b/libs/prisma-models/tests/datamodel_converter_tests.rs
@@ -116,10 +116,14 @@ fn db_names_work() {
 }
 
 #[test]
-#[ignore]
 fn scalar_lists_work() {
     let datamodel = convert(
         r#"
+            datasource pg {
+                provider = "postgres"
+                url = "postgres://localhost/postgres"
+            }
+
             model Test {
                 id String @id @default(cuid())
                 intList Int[]
@@ -130,10 +134,7 @@ fn scalar_lists_work() {
     model
         .assert_scalar_field("intList")
         .assert_type_identifier(TypeIdentifier::Int)
-        .assert_list()
-        .assert_behaviour(FieldBehaviour::ScalarList {
-            strategy: ScalarListStrategy::Relation,
-        });
+        .assert_list();
 }
 
 #[test]

--- a/query-engine/core/src/query_graph_builder/extractors/filters.rs
+++ b/query-engine/core/src/query_graph_builder/extractors/filters.rs
@@ -226,7 +226,7 @@ fn find_index_fields(name: &str, model: &ModelRef) -> QueryGraphBuilderResult<Ve
         .unique_indexes()
         .into_iter()
         .find(|index| &compound_field_name(index) == name)
-        .map(|index| index.fields())
+        .map(|index| index.scalar_fields())
         .ok_or(QueryGraphBuilderError::AssertionError(format!(
             "Unable to resolve {} to an index on model {}",
             name, model.name

--- a/query-engine/core/src/schema_builder/input_type_builder/mod.rs
+++ b/query-engine/core/src/schema_builder/input_type_builder/mod.rs
@@ -126,7 +126,7 @@ pub trait InputTypeBuilderBase<'a>: CachedBuilder<InputObjectType> + InputBuilde
     /// Generates and caches an object type for a unique index.
     fn compound_field_unique_object_type(&self, index: &Index) -> InputObjectTypeRef {
         let name = index.name.as_ref().map(|n| capitalize(n)).unwrap_or_else(|| {
-            let index_fields = index.fields();
+            let index_fields = index.scalar_fields();
             let field_names: Vec<String> = index_fields.iter().map(|sf| capitalize(&sf.name)).collect();
 
             field_names.join("")
@@ -138,7 +138,7 @@ pub trait InputTypeBuilderBase<'a>: CachedBuilder<InputObjectType> + InputBuilde
         let input_object = Arc::new(init_input_object_type(name.clone()));
         self.cache(name, Arc::clone(&input_object));
 
-        let index_fields = index.fields();
+        let index_fields = index.scalar_fields();
         let object_fields = index_fields
             .into_iter()
             .map(|field| {

--- a/query-engine/core/src/schema_builder/utils.rs
+++ b/query-engine/core/src/schema_builder/utils.rs
@@ -136,7 +136,7 @@ pub fn append_opt<T>(vec: &mut Vec<T>, opt: Option<T>) {
 /// Computes a compound field name based on an index.
 pub fn compound_field_name(index: &Index) -> String {
     index.name.clone().unwrap_or_else(|| {
-        let index_fields = index.fields();
+        let index_fields = index.scalar_fields();
         let field_names: Vec<&str> = index_fields.iter().map(|sf| sf.name.as_ref()).collect();
 
         field_names.join("_")


### PR DESCRIPTION
The crash was happening when building the Index from the IndexTemplate.