### PR TITLE
Fix overflows of small stacks in DMMF rendering

### DIFF
--- a/query-engine/prisma/src/dmmf/schema/enum_renderer.rs
+++ b/query-engine/prisma/src/dmmf/schema/enum_renderer.rs
@@ -5,9 +5,9 @@ pub struct DMMFEnumRenderer<'a> {
 }
 
 impl<'a> Renderer<'a, ()> for DMMFEnumRenderer<'a> {
-    fn render(&self, ctx: RenderContext) -> ((), RenderContext) {
+    fn render(&self, ctx: &RenderContext) {
         if ctx.already_rendered(self.enum_type.name()) {
-            return ((), ctx);
+            return;
         }
 
         let values = self.format_enum_values();
@@ -18,7 +18,6 @@ impl<'a> Renderer<'a, ()> for DMMFEnumRenderer<'a> {
         };
 
         ctx.add_enum(self.enum_type.name().to_owned(), rendered);
-        ((), ctx)
     }
 }
 

--- a/query-engine/prisma/src/dmmf/schema/field_renderer.rs
+++ b/query-engine/prisma/src/dmmf/schema/field_renderer.rs
@@ -7,7 +7,7 @@ pub enum DMMFFieldRenderer {
 }
 
 impl<'a> Renderer<'a, DMMFFieldWrapper> for DMMFFieldRenderer {
-    fn render(&self, ctx: RenderContext) -> (DMMFFieldWrapper, RenderContext) {
+    fn render(&self, ctx: &RenderContext) -> DMMFFieldWrapper {
         match self {
             DMMFFieldRenderer::Input(input) => self.render_input_field(Arc::clone(input), ctx),
             DMMFFieldRenderer::Output(output) => self.render_output_field(Arc::clone(output), ctx),
@@ -16,19 +16,19 @@ impl<'a> Renderer<'a, DMMFFieldWrapper> for DMMFFieldRenderer {
 }
 
 impl DMMFFieldRenderer {
-    fn render_input_field(&self, input_field: InputFieldRef, ctx: RenderContext) -> (DMMFFieldWrapper, RenderContext) {
-        let (type_info, ctx) = input_field.field_type.into_renderer().render(ctx);
+    fn render_input_field(&self, input_field: InputFieldRef, ctx: &RenderContext) -> DMMFFieldWrapper {
+        let type_info = input_field.field_type.into_renderer().render(ctx);
         let field = DMMFInputField {
             name: input_field.name.clone(),
             input_type: type_info,
         };
 
-        (DMMFFieldWrapper::Input(field), ctx)
+        DMMFFieldWrapper::Input(field)
     }
 
-    fn render_output_field(&self, field: FieldRef, ctx: RenderContext) -> (DMMFFieldWrapper, RenderContext) {
-        let (args, ctx) = self.render_arguments(&field.arguments, ctx);
-        let (output_type, ctx) = field.field_type.into_renderer().render(ctx);
+    fn render_output_field(&self, field: FieldRef, ctx: &RenderContext) -> DMMFFieldWrapper {
+        let args = self.render_arguments(&field.arguments, ctx);
+        let output_type = field.field_type.into_renderer().render(ctx);
         let output_field = DMMFField {
             name: field.name.clone(),
             args,
@@ -36,25 +36,20 @@ impl DMMFFieldRenderer {
         };
 
         ctx.add_mapping(field.name.clone(), field.query_builder.as_ref());
-        (DMMFFieldWrapper::Output(output_field), ctx)
+        DMMFFieldWrapper::Output(output_field)
     }
 
-    fn render_arguments(&self, args: &[Argument], ctx: RenderContext) -> (Vec<DMMFArgument>, RenderContext) {
-        args.iter().fold((vec![], ctx), |(mut prev, ctx), arg| {
-            let (rendered, ctx) = self.render_argument(arg, ctx);
-
-            prev.push(rendered);
-            (prev, ctx)
-        })
+    fn render_arguments(&self, args: &[Argument], ctx: &RenderContext) -> Vec<DMMFArgument> {
+        args.iter().map(|arg| self.render_argument(arg, ctx)).collect()
     }
 
-    fn render_argument(&self, arg: &Argument, ctx: RenderContext) -> (DMMFArgument, RenderContext) {
-        let (input_type, ctx) = (&arg.argument_type).into_renderer().render(ctx);
+    fn render_argument(&self, arg: &Argument, ctx: &RenderContext) -> DMMFArgument {
+        let input_type = (&arg.argument_type).into_renderer().render(ctx);
         let rendered_arg = DMMFArgument {
             name: arg.name.clone(),
             input_type,
         };
 
-        (rendered_arg, ctx)
+        rendered_arg
     }
 }

--- a/query-engine/prisma/src/dmmf/schema/schema_renderer.rs
+++ b/query-engine/prisma/src/dmmf/schema/schema_renderer.rs
@@ -5,11 +5,9 @@ pub struct DMMFSchemaRenderer {
 }
 
 impl<'a> Renderer<'a, ()> for DMMFSchemaRenderer {
-    fn render(&self, ctx: RenderContext) -> ((), RenderContext) {
-        let (_, ctx) = self.query_schema.query.into_renderer().render(ctx);
-        let (_, ctx) = self.query_schema.mutation.into_renderer().render(ctx);
-
-        ((), ctx)
+    fn render(&self, ctx: &RenderContext) {
+        self.query_schema.query.into_renderer().render(ctx);
+        self.query_schema.mutation.into_renderer().render(ctx);
     }
 }
 

--- a/query-engine/prisma/src/dmmf/schema/type_renderer.rs
+++ b/query-engine/prisma/src/dmmf/schema/type_renderer.rs
@@ -7,7 +7,7 @@ pub enum DMMFTypeRenderer<'a> {
 }
 
 impl<'a> Renderer<'a, DMMFTypeInfo> for DMMFTypeRenderer<'a> {
-    fn render(&self, ctx: RenderContext) -> (DMMFTypeInfo, RenderContext) {
+    fn render(&self, ctx: &RenderContext) -> DMMFTypeInfo {
         match self {
             DMMFTypeRenderer::Input(i) => self.render_input_type(i, ctx),
             DMMFTypeRenderer::Output(o) => self.render_output_type(o, ctx),
@@ -16,10 +16,10 @@ impl<'a> Renderer<'a, DMMFTypeInfo> for DMMFTypeRenderer<'a> {
 }
 
 impl<'a> DMMFTypeRenderer<'a> {
-    fn render_input_type(&self, i: &InputType, ctx: RenderContext) -> (DMMFTypeInfo, RenderContext) {
+    fn render_input_type(&self, i: &InputType, ctx: &RenderContext) -> DMMFTypeInfo {
         match i {
             InputType::Object(ref obj) => {
-                let (_, subctx) = obj.into_renderer().render(ctx);
+                obj.into_renderer().render(ctx);
                 let type_info = DMMFTypeInfo {
                     typ: obj.into_arc().name.clone(),
                     kind: TypeKind::Object,
@@ -27,10 +27,10 @@ impl<'a> DMMFTypeRenderer<'a> {
                     is_list: false,
                 };
 
-                (type_info, subctx)
+                type_info
             }
             InputType::Enum(et) => {
-                let (_, subctx) = et.into_renderer().render(ctx);
+                et.into_renderer().render(ctx);
                 let type_info = DMMFTypeInfo {
                     typ: et.name().to_owned(),
                     kind: TypeKind::Enum,
@@ -38,22 +38,22 @@ impl<'a> DMMFTypeRenderer<'a> {
                     is_list: false,
                 };
 
-                (type_info, subctx)
+                type_info
             }
             InputType::List(ref l) => {
-                let (mut type_info, subctx) = self.render_input_type(l, ctx);
+                let mut type_info = self.render_input_type(l, ctx);
                 type_info.is_list = true;
 
-                (type_info, subctx)
+                type_info
             }
             InputType::Opt(ref opt) => {
-                let (mut type_info, subctx) = self.render_input_type(opt, ctx);
+                let mut type_info = self.render_input_type(opt, ctx);
                 type_info.is_required = false;
 
-                (type_info, subctx)
+                type_info
             }
             InputType::Scalar(ScalarType::Enum(et)) => {
-                let (_, subctx) = et.into_renderer().render(ctx);
+                et.into_renderer().render(ctx);
                 let type_info = DMMFTypeInfo {
                     typ: et.name().to_owned(),
                     kind: TypeKind::Scalar,
@@ -61,7 +61,7 @@ impl<'a> DMMFTypeRenderer<'a> {
                     is_list: false,
                 };
 
-                (type_info, subctx)
+                type_info
             }
             InputType::Scalar(ref scalar) => {
                 let stringified = match scalar {
@@ -84,16 +84,16 @@ impl<'a> DMMFTypeRenderer<'a> {
                     is_list: false,
                 };
 
-                (type_info, ctx)
+                type_info
             }
         }
     }
 
     // WIP dedup code
-    fn render_output_type(&self, o: &OutputType, ctx: RenderContext) -> (DMMFTypeInfo, RenderContext) {
+    fn render_output_type(&self, o: &OutputType, ctx: &RenderContext) -> DMMFTypeInfo {
         match o {
             OutputType::Object(ref obj) => {
-                let (_, subctx) = obj.into_renderer().render(ctx);
+                obj.into_renderer().render(ctx);
                 let type_info = DMMFTypeInfo {
                     typ: obj.into_arc().name().to_string(),
                     kind: TypeKind::Object,
@@ -101,10 +101,10 @@ impl<'a> DMMFTypeRenderer<'a> {
                     is_list: false,
                 };
 
-                (type_info, subctx)
+                type_info
             }
             OutputType::Enum(et) => {
-                let (_, subctx) = et.into_renderer().render(ctx);
+                et.into_renderer().render(ctx);
                 let type_info = DMMFTypeInfo {
                     typ: et.name().to_owned(),
                     kind: TypeKind::Enum,
@@ -112,22 +112,22 @@ impl<'a> DMMFTypeRenderer<'a> {
                     is_list: false,
                 };
 
-                (type_info, subctx)
+                type_info
             }
             OutputType::List(ref l) => {
-                let (mut type_info, subctx) = self.render_output_type(l, ctx);
+                let mut type_info = self.render_output_type(l, ctx);
                 type_info.is_list = true;
 
-                (type_info, subctx)
+                type_info
             }
             OutputType::Opt(ref opt) => {
-                let (mut type_info, subctx) = self.render_output_type(opt, ctx);
+                let mut type_info = self.render_output_type(opt, ctx);
                 type_info.is_required = false;
 
-                (type_info, subctx)
+                type_info
             }
             OutputType::Scalar(ScalarType::Enum(et)) => {
-                let (_, subctx) = et.into_renderer().render(ctx);
+                et.into_renderer().render(ctx);
                 let type_info = DMMFTypeInfo {
                     typ: et.name().to_owned(),
                     kind: TypeKind::Scalar,
@@ -135,7 +135,7 @@ impl<'a> DMMFTypeRenderer<'a> {
                     is_list: false,
                 };
 
-                (type_info, subctx)
+                type_info
             }
             OutputType::Scalar(ref scalar) => {
                 let stringified = match scalar {
@@ -158,7 +158,7 @@ impl<'a> DMMFTypeRenderer<'a> {
                     is_list: false,
                 };
 
-                (type_info, ctx)
+                type_info
             }
         }
     }


### PR DESCRIPTION
There were two factors in the DMMF rendering that had multiplicative
effects on stack space use.

- Iterator `fold` used in recursive functions. `fold` itself is
recursive, so this multiplied. Folds are now replaced with for loops.
- The moving back and forth of `RenderContext`, which is a big struct,
compounded with the `fold`s. `RenderContext` is now passed by reference.