### PR TITLE
Test more database versions in introspection

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/tests/db_specific_introspection/mysql/relations_mysql.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/tests/db_specific_introspection/mysql/relations_mysql.rs
@@ -2,7 +2,7 @@ use crate::*;
 use barrel::types;
 use test_harness::*;
 
-#[test_one_connector(connector = "mysql")]
+#[test_each_connector(tags("mysql"))]
 async fn introspecting_a_one_to_one_req_relation_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -28,7 +28,7 @@ async fn introspecting_a_one_to_one_req_relation_should_work(api: &TestApi) {
                id      Int @id @default(autoincrement())
                user_id User
             }
-          
+
             model User {
                id      Int @id @default(autoincrement())
                post Post?
@@ -38,7 +38,7 @@ async fn introspecting_a_one_to_one_req_relation_should_work(api: &TestApi) {
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "mysql")]
+#[test_each_connector(tags("mysql"))]
 async fn introspecting_two_one_to_one_relations_between_the_same_models_should_work(api: &TestApi) {
     let barrel = api.barrel();
     barrel
@@ -77,7 +77,7 @@ async fn introspecting_two_one_to_one_relations_between_the_same_models_should_w
             user_id User  @relation("Post_user_idToUser")
             user    User? @relation("PostToUser_post_id", references: [post_id])
         }
-    
+
         model User {
             id      Int @id @default(autoincrement())
             post_id Post  @relation("PostToUser_post_id")
@@ -88,7 +88,7 @@ async fn introspecting_two_one_to_one_relations_between_the_same_models_should_w
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "mysql")]
+#[test_each_connector(tags("mysql"))]
 async fn introspecting_a_one_to_one_relation_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -109,23 +109,23 @@ async fn introspecting_a_one_to_one_relation_should_work(api: &TestApi) {
         )
         .await;
 
-    let dm = r#"        
+    let dm = r#"
             model Post {
                id      Int @id @default(autoincrement())
                user_id User?
             }
-            
+
             model User {
                id      Int @id @default(autoincrement())
-               post Post? 
-              
+               post Post?
+
             }
         "#;
     let result = dbg!(api.introspect().await);
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "mysql")]
+#[test_each_connector(tags("mysql"))]
 async fn introspecting_a_one_to_one_relation_referencing_non_id_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -143,23 +143,23 @@ async fn introspecting_a_one_to_one_relation_referencing_non_id_should_work(api:
             });
         })
         .await;
-    let dm = r#"        
+    let dm = r#"
             model Post {
-               id           Int     @id @default(autoincrement())   
+               id           Int     @id @default(autoincrement())
                user_email   User?   @relation(references: [email])
             }
-            
+
             model User {
-               email        String? @unique 
+               email        String? @unique
                id           Int     @id  @default(autoincrement())
-               post         Post? 
+               post         Post?
             }
         "#;
     let result = dbg!(api.introspect().await);
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "mysql")]
+#[test_each_connector(tags("mysql"))]
 async fn introspecting_a_one_to_many_relation_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -180,24 +180,24 @@ async fn introspecting_a_one_to_many_relation_should_work(api: &TestApi) {
         )
         .await;
 
-    let dm = r#"  
+    let dm = r#"
             model Post {
                id      Int @id @default(autoincrement())
                user_id User?
-               
+
                @@index([user_id], name: "user_id")
             }
-            
+
             model User {
                id      Int @id @default(autoincrement())
-               posts Post[] 
+               posts Post[]
             }
         "#;
     let result = dbg!(api.introspect().await);
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "mysql")]
+#[test_each_connector(tags("mysql"))]
 async fn introspecting_a_one_req_to_many_relation_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -222,20 +222,20 @@ async fn introspecting_a_one_req_to_many_relation_should_work(api: &TestApi) {
             model Post {
                id      Int @id @default(autoincrement())
                user_id User
-               
+
                @@index([user_id], name: "user_id")
             }
-            
+
             model User {
                id      Int @id @default(autoincrement())
-               posts Post[] 
+               posts Post[]
             }
        "#;
     let result = dbg!(api.introspect().await);
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "mysql")]
+#[test_each_connector(tags("mysql"))]
 async fn introspecting_a_prisma_many_to_many_relation_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -264,12 +264,12 @@ async fn introspecting_a_prisma_many_to_many_relation_should_work(api: &TestApi)
     let dm = r#"
             model Post {
                id      Int @id @default(autoincrement())
-               users User[]  
+               users User[]
             }
-            
+
             model User {
                id      Int @id @default(autoincrement())
-               posts Post[] 
+               posts Post[]
             }
         "#;
     let result = dbg!(api.introspect().await);
@@ -277,7 +277,7 @@ async fn introspecting_a_prisma_many_to_many_relation_should_work(api: &TestApi)
 }
 
 // currently disallowed by the validator since the relation tables do not have ids
-//#[test_one_connector(connector = "mysql")]
+//#[test_each_connector(tags("mysql"))]
 //async fn introspecting_a_many_to_many_relation_should_work(api: &TestApi) {
 //    let barrel = api.barrel();
 //    let _setup_schema = barrel
@@ -325,7 +325,7 @@ async fn introspecting_a_prisma_many_to_many_relation_should_work(api: &TestApi)
 //    custom_assert(&result, dm);
 //}
 //
-//#[test_one_connector(connector = "mysql")]
+//#[test_each_connector(tags("mysql"))]
 //async fn introspecting_a_many_to_many_relation_with_extra_fields_should_work(api: &TestApi) {
 //    let barrel = api.barrel();
 //    let _setup_schema = barrel
@@ -375,7 +375,7 @@ async fn introspecting_a_prisma_many_to_many_relation_should_work(api: &TestApi)
 //    custom_assert(&result, dm);
 //}
 
-#[test_one_connector(connector = "mysql")]
+#[test_each_connector(tags("mysql"))]
 async fn introspecting_a_many_to_many_relation_with_an_id_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -406,26 +406,26 @@ async fn introspecting_a_many_to_many_relation_with_an_id_should_work(api: &Test
                id      Int @id @default(autoincrement())
                postsToUserses PostsToUsers[] @relation(references: [post_id])
             }
-            
+
             model PostsToUsers {
-              id      Int @id 
-              post_id Post 
+              id      Int @id
+              post_id Post
               user_id User
-              
-              @@index([post_id], name: "post_id")  
+
+              @@index([post_id], name: "post_id")
               @@index([user_id], name: "user_id")
             }
-            
+
             model User {
                id      Int @id @default(autoincrement())
-               postsToUserses PostsToUsers[] 
+               postsToUserses PostsToUsers[]
             }
         "#;
     let result = dbg!(api.introspect().await);
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "mysql")]
+#[test_each_connector(tags("mysql"))]
 async fn introspecting_a_self_relation_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -434,7 +434,7 @@ async fn introspecting_a_self_relation_should_work(api: &TestApi) {
                 migration.create_table("User", |t| {
                     t.add_column("id", types::primary());
                     t.inject_custom(
-                        "recruited_by INTEGER, 
+                        "recruited_by INTEGER,
                      direct_report INTEGER,
                      FOREIGN KEY (`recruited_by`) REFERENCES `User` (`id`),
                      FOREIGN KEY (`direct_report`) REFERENCES `User` (`id`)",
@@ -452,8 +452,8 @@ async fn introspecting_a_self_relation_should_work(api: &TestApi) {
                 recruited_by                   User?  @relation("UserToUser_recruited_by")
                 users_UserToUser_direct_report User[] @relation("UserToUser_direct_report")
                 users_UserToUser_recruited_by  User[] @relation("UserToUser_recruited_by")
-                
-                @@index([direct_report], name: "direct_report")  
+
+                @@index([direct_report], name: "direct_report")
                 @@index([recruited_by], name: "recruited_by")
             }
         "#;
@@ -464,7 +464,7 @@ async fn introspecting_a_self_relation_should_work(api: &TestApi) {
 // on delete cascade
 
 // TODO: bring `onDelete` back once `prisma migrate` is a thing
-//#[test_one_connector(connector = "mysql")]
+//#[test_each_connector(tags("mysql"))]
 async fn introspecting_cascading_delete_behaviour_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -484,14 +484,14 @@ async fn introspecting_cascading_delete_behaviour_should_work(api: &TestApi) {
         )
         .await;
 
-    let dm = r#"  
+    let dm = r#"
             model Post {
                id      Int @id @default(autoincrement())
                user_id User?
-                 
+
                @@index([user_id], name: "user_id")
             }
-            
+
             model User {
                id      Int @id @default(autoincrement())
                posts Post[] @relation(onDelete: CASCADE)
@@ -501,7 +501,7 @@ async fn introspecting_cascading_delete_behaviour_should_work(api: &TestApi) {
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "mysql")]
+#[test_each_connector(tags("mysql"))]
 async fn introspecting_id_fields_with_foreign_key_should_ignore_the_relation(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel

--- a/introspection-engine/connectors/sql-introspection-connector/tests/db_specific_introspection/mysql/relations_with_compound_fk_mysql.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/tests/db_specific_introspection/mysql/relations_with_compound_fk_mysql.rs
@@ -2,7 +2,7 @@ use crate::*;
 use barrel::types;
 use test_harness::*;
 
-#[test_one_connector(connector = "mysql")]
+#[test_each_connector(tags("mysql"))]
 #[test]
 async fn compound_foreign_keys_should_work_for_one_to_one_relations(api: &TestApi) {
     let barrel = api.barrel();
@@ -26,14 +26,14 @@ async fn compound_foreign_keys_should_work_for_one_to_one_relations(api: &TestAp
     let dm = r#"
             model Post {
                 id      Int                 @id  @default(autoincrement())
-                user    User?               @map(["user_id", "user_age"]) @relation(references:[id, age]) 
+                user    User?               @map(["user_id", "user_age"]) @relation(references:[id, age])
             }
 
             model User {
                age      Int
                id       Int                 @id  @default(autoincrement())
                post     Post?
-               
+
                @@unique([id, age], name: "user_unique")
             }
         "#;
@@ -41,7 +41,7 @@ async fn compound_foreign_keys_should_work_for_one_to_one_relations(api: &TestAp
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "mysql")]
+#[test_each_connector(tags("mysql"))]
 #[test]
 async fn compound_foreign_keys_should_work_for_required_one_to_one_relations(api: &TestApi) {
     let barrel = api.barrel();
@@ -65,14 +65,14 @@ async fn compound_foreign_keys_should_work_for_required_one_to_one_relations(api
     let dm = r#"
             model Post {
                 id      Int                 @id   @default(autoincrement())
-                user    User                @map(["user_id", "user_age"]) @relation(references:[id, age]) 
+                user    User                @map(["user_id", "user_age"]) @relation(references:[id, age])
             }
 
             model User {
                age     Int
                id       Int                 @id   @default(autoincrement())
                post     Post?
-               
+
                @@unique([id, age], name: "user_unique")
             }
         "#;
@@ -80,7 +80,7 @@ async fn compound_foreign_keys_should_work_for_required_one_to_one_relations(api
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "mysql")]
+#[test_each_connector(tags("mysql"))]
 #[test]
 async fn compound_foreign_keys_should_work_for_one_to_many_relations(api: &TestApi) {
     let barrel = api.barrel();
@@ -103,8 +103,8 @@ async fn compound_foreign_keys_should_work_for_one_to_many_relations(api: &TestA
     let dm = r#"
             model Post {
                 id      Int                 @id  @default(autoincrement())
-                user    User?               @map(["user_id", "user_age"]) @relation(references:[id, age]) 
-                
+                user    User?               @map(["user_id", "user_age"]) @relation(references:[id, age])
+
                 @@index([user], name: "user_id")
             }
 
@@ -112,7 +112,7 @@ async fn compound_foreign_keys_should_work_for_one_to_many_relations(api: &TestA
                age      Int
                id       Int                 @id  @default(autoincrement())
                posts    Post[]
-               
+
                @@unique([id, age], name: "user_unique")
             }
         "#;
@@ -120,7 +120,7 @@ async fn compound_foreign_keys_should_work_for_one_to_many_relations(api: &TestA
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "mysql")]
+#[test_each_connector(tags("mysql"))]
 #[test]
 async fn compound_foreign_keys_should_work_for_required_one_to_many_relations(api: &TestApi) {
     let barrel = api.barrel();
@@ -143,8 +143,8 @@ async fn compound_foreign_keys_should_work_for_required_one_to_many_relations(ap
     let dm = r#"
             model Post {
                 id      Int                 @id  @default(autoincrement())
-                user    User               @map(["user_id", "user_age"]) @relation(references:[id, age]) 
-                
+                user    User               @map(["user_id", "user_age"]) @relation(references:[id, age])
+
                 @@index([user], name: "user_id")
             }
 
@@ -152,7 +152,7 @@ async fn compound_foreign_keys_should_work_for_required_one_to_many_relations(ap
                age      Int
                id       Int                 @id  @default(autoincrement())
                posts    Post[]
-               
+
                @@unique([id, age], name: "user_unique")
             }
         "#;
@@ -160,7 +160,7 @@ async fn compound_foreign_keys_should_work_for_required_one_to_many_relations(ap
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "mysql")]
+#[test_each_connector(tags("mysql"))]
 #[test]
 async fn compound_foreign_keys_should_work_for_required_self_relations(api: &TestApi) {
     let barrel = api.barrel();
@@ -183,7 +183,7 @@ async fn compound_foreign_keys_should_work_for_required_self_relations(api: &Tes
                id       Int         @id @default(autoincrement())
                person   Person      @map(["partner_id", "partner_age"]) @relation("PersonToPerson_partner_id_partner_age")
                persons  Person[]    @relation("PersonToPerson_partner_id_partner_age")
-               
+
                @@unique([id, age], name: "person_unique")
                @@index([person], name: "partner_id")
             }
@@ -192,7 +192,7 @@ async fn compound_foreign_keys_should_work_for_required_self_relations(api: &Tes
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "mysql")]
+#[test_each_connector(tags("mysql"))]
 #[test]
 async fn compound_foreign_keys_should_work_for_self_relations(api: &TestApi) {
     let barrel = api.barrel();
@@ -215,7 +215,7 @@ async fn compound_foreign_keys_should_work_for_self_relations(api: &TestApi) {
                id       Int         @id @default(autoincrement())
                person   Person?     @map(["partner_id", "partner_age"]) @relation("PersonToPerson_partner_id_partner_age")
                persons  Person[]    @relation("PersonToPerson_partner_id_partner_age")
-               
+
                @@unique([id, age], name: "person_unique")
                @@index([person], name: "partner_id")
             }
@@ -224,7 +224,7 @@ async fn compound_foreign_keys_should_work_for_self_relations(api: &TestApi) {
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "mysql")]
+#[test_each_connector(tags("mysql"))]
 #[test]
 async fn compound_foreign_keys_should_work_with_defaults(api: &TestApi) {
     let barrel = api.barrel();
@@ -247,7 +247,7 @@ async fn compound_foreign_keys_should_work_with_defaults(api: &TestApi) {
                id       Int         @id @default(autoincrement())
                person   Person      @map(["partner_id", "partner_age"]) @relation("PersonToPerson_partner_id_partner_age")
                persons  Person[]    @relation("PersonToPerson_partner_id_partner_age")
-               
+
                @@unique([id, age], name: "person_unique")
                @@index([person], name: "partner_id")
             }
@@ -263,7 +263,7 @@ async fn compound_foreign_keys_should_work_with_defaults(api: &TestApi) {
 // model.indexes contains a multi-field unique index that matches the colums exactly, then it is unique
 // if there are separate uniques it probably should not become a relation
 // what breaks by having an @@unique that refers to fields that do not have a representation on the model anymore due to the merged relation field?
-//#[test_one_connector(connector = "mysql")]
+//#[test_each_connector(tags("mysql"))]
 //#[test]
 //async fn compound_foreign_keys_should_work_for_one_to_one_relations_with_separate_uniques(api: &TestApi) {
 //    let barrel = api.barrel();
@@ -301,7 +301,7 @@ async fn compound_foreign_keys_should_work_with_defaults(api: &TestApi) {
 //    custom_assert(&result, dm);
 //}
 
-#[test_one_connector(connector = "mysql")]
+#[test_each_connector(tags("mysql"))]
 #[test]
 async fn compound_foreign_keys_should_work_for_one_to_many_relations_with_non_unique_index(api: &TestApi) {
     let barrel = api.barrel();
@@ -325,7 +325,7 @@ async fn compound_foreign_keys_should_work_for_one_to_many_relations_with_non_un
             model Post {
                 id      Int                 @id @default(autoincrement())
                 user    User               @map(["user_id", "user_age"]) @relation(references:[id, age])
-                
+
                 @@index([user], name: "user_id")
             }
 
@@ -333,7 +333,7 @@ async fn compound_foreign_keys_should_work_for_one_to_many_relations_with_non_un
                age      Int
                id       Int                 @id @default(autoincrement())
                posts    Post[]
-               
+
                @@unique([id, age], name: "user_unique")
             }
         "#;

--- a/introspection-engine/connectors/sql-introspection-connector/tests/db_specific_introspection/mysql/remapping_database_names_mysql.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/tests/db_specific_introspection/mysql/remapping_database_names_mysql.rs
@@ -2,7 +2,7 @@ use crate::*;
 use barrel::types;
 use test_harness::*;
 
-#[test_one_connector(connector = "mysql")]
+#[test_each_connector(tags("mysql"))]
 async fn remapping_fields_with_invalid_characters_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -39,7 +39,7 @@ async fn remapping_fields_with_invalid_characters_should_work(api: &TestApi) {
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "mysql")]
+#[test_each_connector(tags("mysql"))]
 async fn remapping_tables_with_invalid_characters_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -70,7 +70,7 @@ async fn remapping_tables_with_invalid_characters_should_work(api: &TestApi) {
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "mysql")]
+#[test_each_connector(tags("mysql"))]
 async fn remapping_models_in_relations_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -98,7 +98,7 @@ async fn remapping_models_in_relations_should_work(api: &TestApi) {
                id       Int                             @id  @default(autoincrement())
                name     String
                post     Post?
-               
+
                @@map("User with Space")
             }
         "#;
@@ -106,7 +106,7 @@ async fn remapping_models_in_relations_should_work(api: &TestApi) {
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "mysql")]
+#[test_each_connector(tags("mysql"))]
 #[test]
 async fn remapping_models_in_compound_relations_should_work(api: &TestApi) {
     let barrel = api.barrel();
@@ -130,14 +130,14 @@ async fn remapping_models_in_compound_relations_should_work(api: &TestApi) {
     let dm = r#"
             model Post {
                 id      Int                             @id @default(autoincrement())
-                user_with_Space    User_with_Space      @map(["user_id", "user_age"]) @relation(references:[id, age]) 
+                user_with_Space    User_with_Space      @map(["user_id", "user_age"]) @relation(references:[id, age])
             }
 
             model User_with_Space {
                age      Int
                id       Int                             @id  @default(autoincrement())
                post     Post?
-               
+
                @@map("User with Space")
                @@unique([id, age], name: "user_unique")
             }
@@ -146,7 +146,7 @@ async fn remapping_models_in_compound_relations_should_work(api: &TestApi) {
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "mysql")]
+#[test_each_connector(tags("mysql"))]
 #[test]
 async fn remapping_fields_in_compound_relations_should_work(api: &TestApi) {
     let barrel = api.barrel();
@@ -170,14 +170,14 @@ async fn remapping_fields_in_compound_relations_should_work(api: &TestApi) {
     let dm = r#"
             model Post {
                 id                      Int     @id @default(autoincrement())
-                user                    User    @map(["user_id", "user_age"]) @relation(references:[id, age_that_is_invalid]) 
+                user                    User    @map(["user_id", "user_age"]) @relation(references:[id, age_that_is_invalid])
             }
 
             model User {
                age_that_is_invalid      Int     @map("age-that-is-invalid")
                id                       Int     @id @default(autoincrement())
                post                     Post?
-               
+
                @@unique([id, age_that_is_invalid], name: "user_unique")
             }
         "#;
@@ -185,7 +185,7 @@ async fn remapping_fields_in_compound_relations_should_work(api: &TestApi) {
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "mysql")]
+#[test_each_connector(tags("mysql"))]
 async fn remapping_enum_names_should_work(api: &TestApi) {
     api.barrel()
         .execute(|migration| {
@@ -199,10 +199,10 @@ async fn remapping_enum_names_should_work(api: &TestApi) {
     let dm = r#"
         model MySQLBook {
             color   MySQLBook_color? @map("1color")
-            id      Int     @default(autoincrement()) @id 
+            id      Int     @default(autoincrement()) @id
             @@map("123MySQLBook")
         }
-        
+
         enum MySQLBook_color {
             black
             @@map("123MySQLBook_1color")

--- a/introspection-engine/connectors/sql-introspection-connector/tests/db_specific_introspection/mysql/tables_mysql.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/tests/db_specific_introspection/mysql/tables_mysql.rs
@@ -2,7 +2,7 @@ use crate::*;
 use barrel::types;
 use test_harness::*;
 
-#[test_one_connector(connector = "mysql")]
+#[test_each_connector(tags("mysql"))]
 async fn introspecting_a_simple_table_with_gql_types_must_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -26,7 +26,7 @@ async fn introspecting_a_simple_table_with_gql_types_must_work(api: &TestApi) {
                 date    DateTime
                 float   Float
                 id      Int @id @default(autoincrement())
-                int     Int 
+                int     Int
                 string  String
             }
         "#;
@@ -34,7 +34,7 @@ async fn introspecting_a_simple_table_with_gql_types_must_work(api: &TestApi) {
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "mysql")]
+#[test_each_connector(tags("mysql"))]
 async fn introspecting_a_table_with_compound_primary_keys_must_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -53,7 +53,7 @@ async fn introspecting_a_table_with_compound_primary_keys_must_work(api: &TestAp
     let dm = r#"
             model Blog {
                 authorId String
-                id Int 
+                id Int
                 @@id([id, authorId])
             }
         "#;
@@ -61,7 +61,7 @@ async fn introspecting_a_table_with_compound_primary_keys_must_work(api: &TestAp
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "mysql")]
+#[test_each_connector(tags("mysql"))]
 async fn introspecting_a_table_with_unique_index_must_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -87,7 +87,7 @@ async fn introspecting_a_table_with_unique_index_must_work(api: &TestApi) {
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "mysql")]
+#[test_each_connector(tags("mysql"))]
 async fn introspecting_a_table_with_multi_column_unique_index_must_work(api: &TestApi) {
     let barrel = api.barrel();
     barrel
@@ -116,7 +116,7 @@ async fn introspecting_a_table_with_multi_column_unique_index_must_work(api: &Te
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "mysql")]
+#[test_each_connector(tags("mysql"))]
 async fn introspecting_a_table_with_required_and_optional_columns_must_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -143,7 +143,7 @@ async fn introspecting_a_table_with_required_and_optional_columns_must_work(api:
     custom_assert(&result, dm);
 }
 
-//#[test_one_connector(connector = "mysql")]
+//#[test_each_connector(tags("mysql"))]
 //#[ignore]
 //fn introspecting_a_table_with_datetime_default_values_should_work(api: &TestApi) {
 //    let barrel = api.barrel();
@@ -166,7 +166,7 @@ async fn introspecting_a_table_with_required_and_optional_columns_must_work(api:
 //    custom_assert(&result, dm);
 //}
 
-#[test_one_connector(connector = "mysql")]
+#[test_each_connector(tags("mysql"))]
 async fn introspecting_a_table_with_default_values_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -201,7 +201,7 @@ async fn introspecting_a_table_with_default_values_should_work(api: &TestApi) {
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "mysql")]
+#[test_each_connector(tags("mysql"))]
 async fn introspecting_a_table_with_a_non_unique_index_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -228,7 +228,7 @@ async fn introspecting_a_table_with_a_non_unique_index_should_work(api: &TestApi
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "mysql")]
+#[test_each_connector(tags("mysql"))]
 async fn introspecting_a_table_with_a_multi_column_non_unique_index_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -257,7 +257,7 @@ async fn introspecting_a_table_with_a_multi_column_non_unique_index_should_work(
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "mysql")]
+#[test_each_connector(tags("mysql"))]
 async fn introspecting_a_table_enums_should_work(api: &TestApi) {
     api.barrel()
         .execute(|migration| {
@@ -273,14 +273,14 @@ async fn introspecting_a_table_enums_should_work(api: &TestApi) {
         model Book {
             color   Book_color
             color2  Book_color2
-            id      Int     @default(autoincrement()) @id 
+            id      Int     @default(autoincrement()) @id
         }
-        
+
         enum Book_color{
             black
             white
         }
-        
+
         enum Book_color2{
             black2
             white2
@@ -299,7 +299,7 @@ async fn introspecting_a_table_enums_should_work(api: &TestApi) {
     custom_assert(&result4, dm);
 }
 
-#[test_one_connector(connector = "mysql")]
+#[test_each_connector(tags("mysql"))]
 async fn introspecting_a_table_enums_should_return_alphabetically_even_when_in_different_order(api: &TestApi) {
     api.barrel()
         .execute(|migration| {
@@ -315,14 +315,14 @@ async fn introspecting_a_table_enums_should_return_alphabetically_even_when_in_d
         model Book {
             color   Book_color
             color2  Book_color2
-            id      Int     @default(autoincrement()) @id 
+            id      Int     @default(autoincrement()) @id
         }
-        
+
         enum Book_color{
             black
             white
         }
-        
+
         enum Book_color2{
             black2
             white2

--- a/introspection-engine/connectors/sql-introspection-connector/tests/db_specific_introspection/postgres/native_lists_postgres.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/tests/db_specific_introspection/postgres/native_lists_postgres.rs
@@ -2,7 +2,7 @@ use crate::*;
 use barrel::types;
 use test_harness::*;
 
-#[test_one_connector(connector = "postgres")]
+#[test_each_connector(tags("postgres"))]
 async fn introspecting_native_arrays_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -22,7 +22,7 @@ async fn introspecting_native_arrays_should_work(api: &TestApi) {
               provider = "postgres"
               url = "postgresql://localhost:5432"
             }
-            
+
             model Post {
                bools    Boolean []
                floats   Float []

--- a/introspection-engine/connectors/sql-introspection-connector/tests/db_specific_introspection/postgres/relations_postgres.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/tests/db_specific_introspection/postgres/relations_postgres.rs
@@ -2,7 +2,7 @@ use crate::*;
 use barrel::types;
 use test_harness::*;
 
-#[test_one_connector(connector = "postgres")]
+#[test_each_connector(tags("postgres"))]
 async fn introspecting_a_one_to_one_req_relation_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -22,17 +22,17 @@ async fn introspecting_a_one_to_one_req_relation_should_work(api: &TestApi) {
                id      Int @id @default(autoincrement())
                user_id User
             }
-          
+
             model User {
                id      Int @id @default(autoincrement())
-               post Post? 
+               post Post?
             }
         "#;
     let result = dbg!(api.introspect().await);
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "postgres")]
+#[test_each_connector(tags("postgres"))]
 async fn introspecting_two_one_to_one_relations_between_the_same_models_should_work(api: &TestApi) {
     let barrel = api.barrel();
     barrel
@@ -56,7 +56,7 @@ async fn introspecting_two_one_to_one_relations_between_the_same_models_should_w
                user_id User  @relation("Post_user_idToUser")
                user    User? @relation("PostToUser_post_id", references: [post_id])
             }
-        
+
             model User {
                id      Int @id @default(autoincrement())
                post_id Post  @relation("PostToUser_post_id")
@@ -67,7 +67,7 @@ async fn introspecting_two_one_to_one_relations_between_the_same_models_should_w
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "postgres")]
+#[test_each_connector(tags("postgres"))]
 async fn introspecting_a_one_to_one_relation_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -81,22 +81,22 @@ async fn introspecting_a_one_to_one_relation_should_work(api: &TestApi) {
             });
         })
         .await;
-    let dm = r#"        
+    let dm = r#"
             model Post {
                id      Int @id @default(autoincrement())
                user_id User?
             }
-            
+
             model User {
                id      Int @id @default(autoincrement())
-               post Post? 
+               post Post?
             }
         "#;
     let result = dbg!(api.introspect().await);
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "postgres")]
+#[test_each_connector(tags("postgres"))]
 async fn introspecting_a_one_to_one_relation_referencing_non_id_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -111,23 +111,23 @@ async fn introspecting_a_one_to_one_relation_referencing_non_id_should_work(api:
             });
         })
         .await;
-    let dm = r#"        
+    let dm = r#"
             model Post {
                id           Int     @id  @default(autoincrement())
                user_email   User?   @relation(references: [email])
             }
-            
+
             model User {
-               email        String? @unique 
+               email        String? @unique
                id           Int     @id  @default(autoincrement())
-               post         Post? 
+               post         Post?
             }
         "#;
     let result = dbg!(api.introspect().await);
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "postgres")]
+#[test_each_connector(tags("postgres"))]
 async fn introspecting_a_one_to_many_relation_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -141,22 +141,22 @@ async fn introspecting_a_one_to_many_relation_should_work(api: &TestApi) {
             });
         })
         .await;
-    let dm = r#"  
+    let dm = r#"
             model Post {
                id      Int @id @default(autoincrement())
                user_id User?
             }
-            
+
             model User {
                id      Int @id @default(autoincrement())
-               posts Post[] 
+               posts Post[]
             }
         "#;
     let result = dbg!(api.introspect().await);
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "postgres")]
+#[test_each_connector(tags("postgres"))]
 async fn introspecting_a_one_req_to_many_relation_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -175,17 +175,17 @@ async fn introspecting_a_one_req_to_many_relation_should_work(api: &TestApi) {
                id      Int @id @default(autoincrement())
                user_id User
             }
-            
+
             model User {
                id      Int @id @default(autoincrement())
-               posts Post[] 
+               posts Post[]
             }
        "#;
     let result = dbg!(api.introspect().await);
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "postgres")]
+#[test_each_connector(tags("postgres"))]
 async fn introspecting_a_prisma_many_to_many_relation_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -219,12 +219,12 @@ async fn introspecting_a_prisma_many_to_many_relation_should_work(api: &TestApi)
     let dm = r#"
             model Post {
                id      Int @id @default(autoincrement())
-               users User[] 
+               users User[]
             }
-            
+
             model User {
                id      Int @id @default(autoincrement())
-               posts Post[] 
+               posts Post[]
             }
         "#;
     let result = dbg!(api.introspect().await);
@@ -340,23 +340,22 @@ async fn introspecting_a_many_to_many_relation_with_an_id_should_work(api: &Test
                id      Int @id @default(autoincrement())
                postsToUserses PostsToUsers[] @relation(references: [post_id])
             }
-            
+
             model PostsToUsers {
               id    Int @id
-              post_id Post 
+              post_id Post
               user_id User
             }
-            
+
             model User {
                id      Int @id @default(autoincrement())
-               postsToUserses PostsToUsers[] 
+               postsToUserses PostsToUsers[]
             }
         "#;
     let result = dbg!(api.introspect().await);
     custom_assert(&result, dm);
 }
-
-#[test_one_connector(connector = "postgres")]
+#[test_each_connector(tags("postgres"))]
 async fn introspecting_a_self_relation_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -386,7 +385,7 @@ async fn introspecting_a_self_relation_should_work(api: &TestApi) {
 // on delete cascade
 
 // TODO: bring `onDelete` back once `prisma migrate` is a thing
-//#[test_one_connector(connector = "postgres")]
+//#[test_each_connector(tags("postgres"))]
 async fn introspecting_cascading_delete_behaviour_should_work(api: &TestApi) {
     let barrel = api.barrel();
     barrel
@@ -401,12 +400,12 @@ async fn introspecting_cascading_delete_behaviour_should_work(api: &TestApi) {
         })
         .await;
 
-    let dm = r#"  
+    let dm = r#"
             model Post {
                id      Int @id @default(autoincrement())
                user_id User?
             }
-            
+
             model User {
                id    Int @id @default(autoincrement())
                posts Post[] @relation(onDelete: CASCADE)
@@ -420,7 +419,7 @@ async fn introspecting_cascading_delete_behaviour_should_work(api: &TestApi) {
 
 // native arrays
 
-#[test_one_connector(connector = "postgres")]
+#[test_each_connector(tags("postgres"))]
 async fn introspecting_default_values_on_relations_should_be_ignored(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -454,7 +453,7 @@ async fn introspecting_default_values_on_relations_should_be_ignored(api: &TestA
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "postgres")]
+#[test_each_connector(tags("postgres"))]
 async fn introspecting_default_values_on_lists_should_be_ignored(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -483,7 +482,7 @@ async fn introspecting_default_values_on_lists_should_be_ignored(api: &TestApi) 
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "postgres")]
+#[test_each_connector(tags("postgres"))]
 async fn introspecting_id_fields_with_foreign_key_should_ignore_the_relation(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel

--- a/introspection-engine/connectors/sql-introspection-connector/tests/db_specific_introspection/postgres/relations_with_compound_fk_postgres.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/tests/db_specific_introspection/postgres/relations_with_compound_fk_postgres.rs
@@ -2,7 +2,7 @@ use crate::*;
 use barrel::types;
 use test_harness::*;
 
-#[test_one_connector(connector = "postgres")]
+#[test_each_connector(tags("postgres"))]
 #[test]
 async fn compound_foreign_keys_should_work_for_required_one_to_one_relations(api: &TestApi) {
     let barrel = api.barrel();
@@ -26,14 +26,14 @@ async fn compound_foreign_keys_should_work_for_required_one_to_one_relations(api
     let dm = r#"
             model Post {
                 id      Int                 @id @default(autoincrement())
-                user    User                @map(["user_id", "user_name"]) @relation(references:[id, name]) 
+                user    User                @map(["user_id", "user_name"]) @relation(references:[id, name])
             }
 
             model User {
                id       Int                 @id @default(autoincrement())
                name     String
                post     Post?
-               
+
                @@unique([id, name], name: "user_unique")
             }
         "#;
@@ -41,7 +41,7 @@ async fn compound_foreign_keys_should_work_for_required_one_to_one_relations(api
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "postgres")]
+#[test_each_connector(tags("postgres"))]
 #[test]
 async fn compound_foreign_keys_should_work_for_one_to_one_relations(api: &TestApi) {
     let barrel = api.barrel();
@@ -65,14 +65,14 @@ async fn compound_foreign_keys_should_work_for_one_to_one_relations(api: &TestAp
     let dm = r#"
             model Post {
                 id      Int                 @id @default(autoincrement())
-                user    User?                @map(["user_id", "user_name"]) @relation(references:[id, name]) 
+                user    User?                @map(["user_id", "user_name"]) @relation(references:[id, name])
             }
 
             model User {
                id       Int                 @id @default(autoincrement())
                name     String
                post     Post?
-               
+
                @@unique([id, name], name: "user_unique")
             }
         "#;
@@ -80,7 +80,7 @@ async fn compound_foreign_keys_should_work_for_one_to_one_relations(api: &TestAp
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "postgres")]
+#[test_each_connector(tags("postgres"))]
 #[test]
 async fn compound_foreign_keys_should_work_for_one_to_many_relations(api: &TestApi) {
     let barrel = api.barrel();
@@ -103,14 +103,14 @@ async fn compound_foreign_keys_should_work_for_one_to_many_relations(api: &TestA
     let dm = r#"
             model Post {
                 id      Int                 @id @default(autoincrement())
-                user    User?                @map(["user_id", "user_name"]) @relation(references:[id, name]) 
+                user    User?                @map(["user_id", "user_name"]) @relation(references:[id, name])
             }
 
             model User {
                id       Int                 @id @default(autoincrement())
                name     String
                posts    Post[]
-               
+
                @@unique([id, name], name: "user_unique")
             }
         "#;
@@ -118,7 +118,7 @@ async fn compound_foreign_keys_should_work_for_one_to_many_relations(api: &TestA
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "postgres")]
+#[test_each_connector(tags("postgres"))]
 #[test]
 async fn compound_foreign_keys_should_work_for_required_one_to_many_relations(api: &TestApi) {
     let barrel = api.barrel();
@@ -141,14 +141,14 @@ async fn compound_foreign_keys_should_work_for_required_one_to_many_relations(ap
     let dm = r#"
             model Post {
                 id      Int                 @id @default(autoincrement())
-                user    User                @map(["user_id", "user_name"]) @relation(references:[id, name]) 
+                user    User                @map(["user_id", "user_name"]) @relation(references:[id, name])
             }
 
             model User {
                id       Int                 @id @default(autoincrement())
                name     String
                posts    Post[]
-               
+
                @@unique([id, name], name: "user_unique")
             }
         "#;
@@ -156,7 +156,7 @@ async fn compound_foreign_keys_should_work_for_required_one_to_many_relations(ap
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "postgres")]
+#[test_each_connector(tags("postgres"))]
 #[test]
 async fn compound_foreign_keys_should_work_for_self_relations(api: &TestApi) {
     let barrel = api.barrel();
@@ -181,7 +181,7 @@ async fn compound_foreign_keys_should_work_for_self_relations(api: &TestApi) {
                name     String
                person   Person      @map(["partner_id", "partner_name"]) @relation("PersonToPerson_partner_id_partner_name")
                persons  Person[]    @relation("PersonToPerson_partner_id_partner_name")
-               
+
                @@unique([id, name], name: "person_unique")
             }
         "#;
@@ -189,7 +189,7 @@ async fn compound_foreign_keys_should_work_for_self_relations(api: &TestApi) {
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "postgres")]
+#[test_each_connector(tags("postgres"))]
 #[test]
 async fn compound_foreign_keys_should_work_with_defaults(api: &TestApi) {
     let barrel = api.barrel();
@@ -214,7 +214,7 @@ async fn compound_foreign_keys_should_work_with_defaults(api: &TestApi) {
                name     String
                person   Person      @map(["partner_id", "partner_name"]) @relation("PersonToPerson_partner_id_partner_name")
                persons  Person[]    @relation("PersonToPerson_partner_id_partner_name")
-               
+
                @@unique([id, name], name: "person_unique")
             }
         "#;
@@ -229,7 +229,7 @@ async fn compound_foreign_keys_should_work_with_defaults(api: &TestApi) {
 // model.indexes contains a multi-field unique index that matches the colums exactly, then it is unique
 // if there are separate uniques it probably should not become a relation
 // what breaks by having an @@unique that refers to fields that do not have a representation on the model anymore due to the merged relation field?
-//#[test_one_connector(connector = "postgres")]
+//#[test_each_connector(tags("postgres"))]
 //#[test]
 //async fn compound_foreign_keys_should_work_for_one_to_one_relations_with_separate_uniques(api: &TestApi) {
 //    let barrel = api.barrel();
@@ -267,7 +267,7 @@ async fn compound_foreign_keys_should_work_with_defaults(api: &TestApi) {
 //    custom_assert(&result, dm);
 //}
 
-#[test_one_connector(connector = "postgres")]
+#[test_each_connector(tags("postgres"))]
 #[test]
 async fn compound_foreign_keys_should_work_for_one_to_many_relations_with_non_unique_index(api: &TestApi) {
     let barrel = api.barrel();
@@ -292,7 +292,7 @@ async fn compound_foreign_keys_should_work_for_one_to_many_relations_with_non_un
             model Post {
                 id      Int                @id @default(autoincrement())
                 user    User               @map(["user_id", "user_age"]) @relation(references:[id, age])
-                
+
                 @@index(user, name: "test")
             }
 
@@ -300,7 +300,7 @@ async fn compound_foreign_keys_should_work_for_one_to_many_relations_with_non_un
                age      Int
                id       Int                @id @default(autoincrement())
                posts    Post[]
-               
+
                @@unique([id, age], name: "user_unique")
             }
         "#;

--- a/introspection-engine/connectors/sql-introspection-connector/tests/db_specific_introspection/postgres/remapping_database_names_postgres.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/tests/db_specific_introspection/postgres/remapping_database_names_postgres.rs
@@ -2,7 +2,7 @@ use crate::*;
 use barrel::types;
 use test_harness::*;
 
-#[test_one_connector(connector = "postgres")]
+#[test_each_connector(tags("postgres"))]
 async fn remapping_fields_with_invalid_characters_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -40,7 +40,7 @@ async fn remapping_fields_with_invalid_characters_should_work(api: &TestApi) {
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "postgres")]
+#[test_each_connector(tags("postgres"))]
 async fn remapping_tables_with_invalid_characters_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -71,7 +71,7 @@ async fn remapping_tables_with_invalid_characters_should_work(api: &TestApi) {
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "postgres")]
+#[test_each_connector(tags("postgres"))]
 async fn remapping_models_in_relations_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -99,7 +99,7 @@ async fn remapping_models_in_relations_should_work(api: &TestApi) {
                id       Int                             @id @default(autoincrement())
                name     String
                post     Post?
-               
+
                @@map("User with Space")
             }
         "#;
@@ -107,7 +107,7 @@ async fn remapping_models_in_relations_should_work(api: &TestApi) {
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "postgres")]
+#[test_each_connector(tags("postgres"))]
 #[test]
 async fn remapping_models_in_compound_relations_should_work(api: &TestApi) {
     let barrel = api.barrel();
@@ -133,14 +133,14 @@ async fn remapping_models_in_compound_relations_should_work(api: &TestApi) {
     let dm = r#"
             model Post {
                 id      Int                             @id @default(autoincrement())
-                user_with_Space    User_with_Space      @map(["user_id", "user_name"]) @relation(references:[id, name]) 
+                user_with_Space    User_with_Space      @map(["user_id", "user_name"]) @relation(references:[id, name])
             }
 
             model User_with_Space {
                id       Int                             @id @default(autoincrement())
                name     String
                post     Post?
-               
+
                @@map("User with Space")
                @@unique([id, name], name: "user_unique")
             }
@@ -149,7 +149,7 @@ async fn remapping_models_in_compound_relations_should_work(api: &TestApi) {
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "postgres")]
+#[test_each_connector(tags("postgres"))]
 #[test]
 async fn remapping_fields_in_compound_relations_should_work(api: &TestApi) {
     let barrel = api.barrel();
@@ -175,14 +175,14 @@ async fn remapping_fields_in_compound_relations_should_work(api: &TestApi) {
     let dm = r#"
             model Post {
                 id                      Int     @id @default(autoincrement())
-                user                    User    @map(["user_id", "user_name"]) @relation(references:[id, name_that_is_invalid]) 
+                user                    User    @map(["user_id", "user_name"]) @relation(references:[id, name_that_is_invalid])
             }
 
             model User {
                id                       Int     @id @default(autoincrement())
                name_that_is_invalid     String  @map("name-that-is-invalid")
                post                     Post?
-               
+
                @@unique([id, name_that_is_invalid], name: "user_unique")
             }
         "#;
@@ -190,7 +190,7 @@ async fn remapping_fields_in_compound_relations_should_work(api: &TestApi) {
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "postgres")]
+#[test_each_connector(tags("postgres"))]
 async fn remapping_enum_names_should_work(api: &TestApi) {
     let sql1 = format!("CREATE Type _color as ENUM ('black')");
     api.database().execute_raw(&sql1, &[]).await.unwrap();
@@ -207,9 +207,9 @@ async fn remapping_enum_names_should_work(api: &TestApi) {
     let dm = r#"
         model Book {
             color   color
-            id      Int     @default(autoincrement()) @id 
+            id      Int     @default(autoincrement()) @id
         }
-        
+
         enum color {
             black
             @@map("_color")
@@ -220,7 +220,7 @@ async fn remapping_enum_names_should_work(api: &TestApi) {
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "postgres")]
+#[test_each_connector(tags("postgres"))]
 async fn remapping_compound_primary_keys_should_work(api: &TestApi) {
     api.barrel()
         .execute(|migration| {
@@ -236,7 +236,7 @@ async fn remapping_compound_primary_keys_should_work(api: &TestApi) {
         model User {
             first_name   String
             last_name   String @map("last@name")
-        
+
             @@id([first_name, last_name])
         }
     "#;

--- a/introspection-engine/connectors/sql-introspection-connector/tests/db_specific_introspection/postgres/tables_postgres.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/tests/db_specific_introspection/postgres/tables_postgres.rs
@@ -2,7 +2,7 @@ use crate::*;
 use barrel::types;
 use test_harness::*;
 
-#[test_one_connector(connector = "postgres")]
+#[test_each_connector(tags("postgres"))]
 async fn introspecting_a_simple_table_with_gql_types_must_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -32,7 +32,7 @@ async fn introspecting_a_simple_table_with_gql_types_must_work(api: &TestApi) {
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "postgres")]
+#[test_each_connector(tags("postgres"))]
 async fn introspecting_a_table_with_compound_primary_keys_must_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -55,7 +55,7 @@ async fn introspecting_a_table_with_compound_primary_keys_must_work(api: &TestAp
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "postgres")]
+#[test_each_connector(tags("postgres"))]
 async fn introspecting_a_table_with_unique_index_must_work(api: &TestApi) {
     let barrel = api.barrel();
     barrel
@@ -78,7 +78,7 @@ async fn introspecting_a_table_with_unique_index_must_work(api: &TestApi) {
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "postgres")]
+#[test_each_connector(tags("postgres"))]
 async fn introspecting_a_table_with_multi_column_unique_index_must_work(api: &TestApi) {
     let barrel = api.barrel();
     barrel
@@ -104,7 +104,7 @@ async fn introspecting_a_table_with_multi_column_unique_index_must_work(api: &Te
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "postgres")]
+#[test_each_connector(tags("postgres"))]
 async fn introspecting_a_table_with_required_and_optional_columns_must_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -127,7 +127,7 @@ async fn introspecting_a_table_with_required_and_optional_columns_must_work(api:
     custom_assert(&result, dm);
 }
 
-//#[test_one_connector(connector = "postgres")]
+//#[test_each_connector(tags("postgres"))]
 //#[ignore]
 //fn introspecting_a_table_with_datetime_default_values_should_work(api: &TestApi) {
 //    let barrel = api.barrel();
@@ -149,7 +149,7 @@ async fn introspecting_a_table_with_required_and_optional_columns_must_work(api:
 //    custom_assert(&result, dm);
 //}
 
-#[test_one_connector(connector = "postgres")]
+#[test_each_connector(tags("postgres"))]
 async fn introspecting_a_table_with_default_values_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -180,7 +180,7 @@ async fn introspecting_a_table_with_default_values_should_work(api: &TestApi) {
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "postgres")]
+#[test_each_connector(tags("postgres"))]
 async fn introspecting_a_table_with_a_non_unique_index_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -204,7 +204,7 @@ async fn introspecting_a_table_with_a_non_unique_index_should_work(api: &TestApi
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "postgres")]
+#[test_each_connector(tags("postgres"))]
 async fn introspecting_a_table_with_a_multi_column_non_unique_index_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -230,7 +230,7 @@ async fn introspecting_a_table_with_a_multi_column_non_unique_index_should_work(
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "postgres")]
+#[test_each_connector(tags("postgres"))]
 async fn introspecting_a_table_enums_should_work(api: &TestApi) {
     let sql = format!("CREATE Type color as ENUM ( 'black', 'white')");
     let sql2 = format!("CREATE Type color2 as ENUM ( 'black2', 'white2')");
@@ -252,14 +252,14 @@ async fn introspecting_a_table_enums_should_work(api: &TestApi) {
         model Book {
             color   color
             color2  color2
-            id      Int     @default(autoincrement()) @id 
+            id      Int     @default(autoincrement()) @id
         }
-        
+
         enum color{
             black
             white
         }
-        
+
         enum color2{
             black2
             white2
@@ -278,7 +278,7 @@ async fn introspecting_a_table_enums_should_work(api: &TestApi) {
     custom_assert(&result4, dm);
 }
 
-#[test_one_connector(connector = "postgres")]
+#[test_each_connector(tags("postgres"))]
 async fn introspecting_a_table_enums_should_return_alphabetically_even_when_in_different_order(api: &TestApi) {
     let sql1 = format!("CREATE Type color as ENUM ( 'black', 'white')");
     let sql2 = format!("CREATE Type color2 as ENUM ( 'black2', 'white2')");
@@ -300,14 +300,14 @@ async fn introspecting_a_table_enums_should_return_alphabetically_even_when_in_d
         model Book {
             color   color
             color2  color2
-            id      Int     @default(autoincrement()) @id 
+            id      Int     @default(autoincrement()) @id
         }
-        
+
         enum color{
             black
             white
         }
-        
+
         enum color2{
             black2
             white2
@@ -326,7 +326,7 @@ async fn introspecting_a_table_enums_should_return_alphabetically_even_when_in_d
     custom_assert(&result4, dm);
 }
 
-#[test_one_connector(connector = "postgres")]
+#[test_each_connector(tags("postgres"))]
 async fn introspecting_a_table_enums_array_should_work(api: &TestApi) {
     let sql = format!("CREATE Type color as ENUM ( 'black', 'white')");
 
@@ -346,12 +346,12 @@ async fn introspecting_a_table_enums_array_should_work(api: &TestApi) {
               provider = "postgres"
               url = "postgresql://localhost:5432"
         }
-    
+
         model Book {
             color   color[]
-            id      Int     @default(autoincrement()) @id 
+            id      Int     @default(autoincrement()) @id
         }
-        
+
         enum color{
             black
             white

--- a/introspection-engine/connectors/sql-introspection-connector/tests/db_specific_introspection/sqlite/relations_sqlite.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/tests/db_specific_introspection/sqlite/relations_sqlite.rs
@@ -2,7 +2,7 @@ use crate::*;
 use barrel::types;
 use test_harness::*;
 
-#[test_one_connector(connector = "sqlite")]
+#[test_each_connector(tags("sqlite"))]
 async fn introspecting_a_one_to_one_req_relation_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -23,9 +23,9 @@ async fn introspecting_a_one_to_one_req_relation_should_work(api: &TestApi) {
     let dm = r#"
             model User {
                id Int @id @default(autoincrement())
-               post Post? 
+               post Post?
             }
-            
+
             model Post {
                id Int @id @default(autoincrement())
                user_id User
@@ -35,7 +35,7 @@ async fn introspecting_a_one_to_one_req_relation_should_work(api: &TestApi) {
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "sqlite")]
+#[test_each_connector(tags("sqlite"))]
 async fn introspecting_two_one_to_one_relations_between_the_same_models_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -63,7 +63,7 @@ async fn introspecting_two_one_to_one_relations_between_the_same_models_should_w
                post_id Post  @relation("PostToUser_post_id")
                post Post?    @relation("Post_user_idToUser")
             }
-            
+
             model Post {
                id Int @id @default(autoincrement())
                user_id User  @relation("Post_user_idToUser")
@@ -74,7 +74,7 @@ async fn introspecting_two_one_to_one_relations_between_the_same_models_should_w
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "sqlite")]
+#[test_each_connector(tags("sqlite"))]
 async fn introspecting_a_one_to_one_relation_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -95,9 +95,9 @@ async fn introspecting_a_one_to_one_relation_should_work(api: &TestApi) {
     let dm = r#"
             model User {
                id Int @id @default(autoincrement())
-               post Post? 
+               post Post?
             }
-            
+
             model Post {
                id Int @id @default(autoincrement())
                user_id User?
@@ -107,7 +107,7 @@ async fn introspecting_a_one_to_one_relation_should_work(api: &TestApi) {
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "sqlite")]
+#[test_each_connector(tags("sqlite"))]
 async fn introspecting_a_one_to_one_relation_referencing_non_id_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -127,11 +127,11 @@ async fn introspecting_a_one_to_one_relation_referencing_non_id_should_work(api:
         .await;
     let dm = r#"
             model User {
-               email        String? @unique 
+               email        String? @unique
                id           Int     @id  @default(autoincrement())
-               post         Post? 
+               post         Post?
             }
-            
+
             model Post {
                id           Int     @id   @default(autoincrement())
                user_email   User?   @relation(references: [email])
@@ -141,7 +141,7 @@ async fn introspecting_a_one_to_one_relation_referencing_non_id_should_work(api:
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "sqlite")]
+#[test_each_connector(tags("sqlite"))]
 async fn introspecting_a_one_to_many_relation_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -162,9 +162,9 @@ async fn introspecting_a_one_to_many_relation_should_work(api: &TestApi) {
     let dm = r#"
             model User {
                id Int @id @default(autoincrement())
-               posts Post[] 
+               posts Post[]
             }
-            
+
             model Post {
                id Int @id @default(autoincrement())
                user_id User?
@@ -174,7 +174,7 @@ async fn introspecting_a_one_to_many_relation_should_work(api: &TestApi) {
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "sqlite")]
+#[test_each_connector(tags("sqlite"))]
 async fn introspecting_a_one_req_to_many_relation_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -195,9 +195,9 @@ async fn introspecting_a_one_req_to_many_relation_should_work(api: &TestApi) {
     let dm = r#"
             model User {
                id Int @id @default(autoincrement())
-               posts Post[] 
+               posts Post[]
             }
-            
+
             model Post {
                id Int @id @default(autoincrement())
                user_id User
@@ -207,7 +207,7 @@ async fn introspecting_a_one_req_to_many_relation_should_work(api: &TestApi) {
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "sqlite")]
+#[test_each_connector(tags("sqlite"))]
 async fn introspecting_a_prisma_many_to_many_relation_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -245,12 +245,12 @@ async fn introspecting_a_prisma_many_to_many_relation_should_work(api: &TestApi)
     let dm = r#"
             model User {
                id Int @id @default(autoincrement())
-               posts Post[] 
+               posts Post[]
             }
-            
+
             model Post {
                id Int @id @default(autoincrement())
-               users User[] 
+               users User[]
             }
         "#;
     let result = dbg!(api.introspect().await);
@@ -258,7 +258,7 @@ async fn introspecting_a_prisma_many_to_many_relation_should_work(api: &TestApi)
 }
 
 // currently disallowed by the validator since the relation tables do not have ids
-//#[test_one_connector(connector = "sqlite")]
+//#[test_each_connector(tags("sqlite"))]
 //async fn introspecting_a_many_to_many_relation_should_work(api: &TestApi) {
 //    let barrel = api.barrel();
 //    let _setup_schema = barrel
@@ -300,7 +300,7 @@ async fn introspecting_a_prisma_many_to_many_relation_should_work(api: &TestApi)
 //    custom_assert(&result, dm);
 //}
 //
-//#[test_one_connector(connector = "sqlite")]
+//#[test_each_connector(tags("sqlite"))]
 //async fn introspecting_a_many_to_many_relation_with_extra_fields_should_work(api: &TestApi) {
 //    let barrel = api.barrel();
 //    let _setup_schema = barrel
@@ -344,7 +344,7 @@ async fn introspecting_a_prisma_many_to_many_relation_should_work(api: &TestApi)
 //    custom_assert(&result, dm);
 //}
 
-#[test_one_connector(connector = "sqlite")]
+#[test_each_connector(tags("sqlite"))]
 async fn introspecting_a_many_to_many_relation_with_an_id_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -370,17 +370,17 @@ async fn introspecting_a_many_to_many_relation_with_an_id_should_work(api: &Test
     let dm = r#"
             model User {
                id Int @id @default(autoincrement())
-               postsToUserses PostsToUsers[] 
+               postsToUserses PostsToUsers[]
             }
-            
+
             model Post {
                id Int @id @default(autoincrement())
                postsToUserses PostsToUsers[] @relation(references: [post_id])
             }
-            
+
             model PostsToUsers {
               id      Int @id @default(autoincrement())
-              post_id Post 
+              post_id Post
               user_id User
             }
         "#;
@@ -388,7 +388,7 @@ async fn introspecting_a_many_to_many_relation_with_an_id_should_work(api: &Test
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "sqlite")]
+#[test_each_connector(tags("sqlite"))]
 async fn introspecting_a_self_relation_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -421,7 +421,7 @@ async fn introspecting_a_self_relation_should_work(api: &TestApi) {
 // on delete cascade
 
 // TODO: bring `onDelete` back once `prisma migrate` is a thing
-//#[test_one_connector(connector = "sqlite")]
+//#[test_each_connector(tags("sqlite"))]
 async fn introspecting_cascading_delete_behaviour_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -444,7 +444,7 @@ async fn introspecting_cascading_delete_behaviour_should_work(api: &TestApi) {
                id      Int @id @default(autoincrement())
                posts Post[] @relation(onDelete: CASCADE)
             }
-            
+
             model Post {
                id      Int @id @default(autoincrement())
                user_id User?
@@ -454,7 +454,7 @@ async fn introspecting_cascading_delete_behaviour_should_work(api: &TestApi) {
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "sqlite")]
+#[test_each_connector(tags("sqlite"))]
 async fn introspecting_id_fields_with_foreign_key_should_ignore_the_relation(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -478,7 +478,7 @@ async fn introspecting_id_fields_with_foreign_key_should_ignore_the_relation(api
             model Post {
                test    String
                user_id Int @id @default(autoincrement())
-            } 
+            }
         "#;
     let result = dbg!(api.introspect().await);
     custom_assert(&result, dm);

--- a/introspection-engine/connectors/sql-introspection-connector/tests/db_specific_introspection/sqlite/relations_with_compound_fk_sqlite.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/tests/db_specific_introspection/sqlite/relations_with_compound_fk_sqlite.rs
@@ -2,7 +2,7 @@ use crate::*;
 use barrel::types;
 use test_harness::*;
 
-#[test_one_connector(connector = "sqlite")]
+#[test_each_connector(tags("sqlite"))]
 #[test]
 async fn compound_foreign_keys_should_work_for_one_to_one_relations(api: &TestApi) {
     let barrel = api.barrel();
@@ -25,16 +25,16 @@ async fn compound_foreign_keys_should_work_for_one_to_one_relations(api: &TestAp
 
     let dm = r#"
             model User {
-               age      Int 
+               age      Int
                id       Int                 @id @default(autoincrement())
                post     Post?
-               
+
                @@unique([id, age], name: "sqlite_autoindex_User_1")
             }
-            
+
             model Post {
                 id      Int                 @id @default(autoincrement())
-                user    User?               @map(["user_id", "user_age"]) @relation(references:[id, age]) 
+                user    User?               @map(["user_id", "user_age"]) @relation(references:[id, age])
             }
 
         "#;
@@ -42,7 +42,7 @@ async fn compound_foreign_keys_should_work_for_one_to_one_relations(api: &TestAp
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "sqlite")]
+#[test_each_connector(tags("sqlite"))]
 #[test]
 async fn compound_foreign_keys_should_work_for_required_one_to_one_relations(api: &TestApi) {
     let barrel = api.barrel();
@@ -68,13 +68,13 @@ async fn compound_foreign_keys_should_work_for_required_one_to_one_relations(api
                age     Int
                id       Int                 @id @default(autoincrement())
                post     Post?
-               
+
                @@unique([id, age], name: "sqlite_autoindex_User_1")
             }
-            
+
             model Post {
                 id      Int                 @id  @default(autoincrement())
-                user    User                @map(["user_id", "user_age"]) @relation(references:[id, age]) 
+                user    User                @map(["user_id", "user_age"]) @relation(references:[id, age])
             }
 
         "#;
@@ -82,7 +82,7 @@ async fn compound_foreign_keys_should_work_for_required_one_to_one_relations(api
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "sqlite")]
+#[test_each_connector(tags("sqlite"))]
 #[test]
 async fn compound_foreign_keys_should_work_for_one_to_many_relations(api: &TestApi) {
     let barrel = api.barrel();
@@ -107,13 +107,13 @@ async fn compound_foreign_keys_should_work_for_one_to_many_relations(api: &TestA
                age      Int
                id       Int                 @id @default(autoincrement())
                posts    Post[]
-               
+
                @@unique([id, age], name: "sqlite_autoindex_User_1")
             }
-            
+
             model Post {
                 id      Int                 @id @default(autoincrement())
-                user    User?               @map(["user_id", "user_age"]) @relation(references:[id, age]) 
+                user    User?               @map(["user_id", "user_age"]) @relation(references:[id, age])
             }
 
         "#;
@@ -121,7 +121,7 @@ async fn compound_foreign_keys_should_work_for_one_to_many_relations(api: &TestA
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "sqlite")]
+#[test_each_connector(tags("sqlite"))]
 #[test]
 async fn compound_foreign_keys_should_work_for_required_one_to_many_relations(api: &TestApi) {
     let barrel = api.barrel();
@@ -146,20 +146,20 @@ async fn compound_foreign_keys_should_work_for_required_one_to_many_relations(ap
                age      Int
                id       Int                 @id @default(autoincrement())
                posts    Post[]
-               
+
                @@unique([id, age], name: "sqlite_autoindex_User_1")
             }
-            
+
             model Post {
                 id      Int                 @id @default(autoincrement())
-                user    User               @map(["user_id", "user_age"]) @relation(references:[id, age]) 
+                user    User               @map(["user_id", "user_age"]) @relation(references:[id, age])
             }
         "#;
     let result = dbg!(api.introspect().await);
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "sqlite")]
+#[test_each_connector(tags("sqlite"))]
 #[test]
 async fn compound_foreign_keys_should_work_for_required_self_relations(api: &TestApi) {
     let barrel = api.barrel();
@@ -182,7 +182,7 @@ async fn compound_foreign_keys_should_work_for_required_self_relations(api: &Tes
                id       Int         @id  @default(autoincrement())
                person   Person      @map(["partner_id", "partner_age"]) @relation("PersonToPerson_partner_id_partner_age")
                persons  Person[]    @relation("PersonToPerson_partner_id_partner_age")
-               
+
                @@unique([id, age], name: "sqlite_autoindex_Person_1")
             }
         "#;
@@ -190,7 +190,7 @@ async fn compound_foreign_keys_should_work_for_required_self_relations(api: &Tes
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "sqlite")]
+#[test_each_connector(tags("sqlite"))]
 #[test]
 async fn compound_foreign_keys_should_work_for_self_relations(api: &TestApi) {
     let barrel = api.barrel();
@@ -213,7 +213,7 @@ async fn compound_foreign_keys_should_work_for_self_relations(api: &TestApi) {
                id       Int         @id  @default(autoincrement())
                person   Person?     @map(["partner_id", "partner_age"]) @relation("PersonToPerson_partner_id_partner_age")
                persons  Person[]    @relation("PersonToPerson_partner_id_partner_age")
-               
+
                @@unique([id, age], name: "sqlite_autoindex_Person_1")
             }
         "#;
@@ -221,7 +221,7 @@ async fn compound_foreign_keys_should_work_for_self_relations(api: &TestApi) {
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "sqlite")]
+#[test_each_connector(tags("sqlite"))]
 #[test]
 async fn compound_foreign_keys_should_work_with_defaults(api: &TestApi) {
     let barrel = api.barrel();
@@ -244,7 +244,7 @@ async fn compound_foreign_keys_should_work_with_defaults(api: &TestApi) {
                id       Int         @id  @default(autoincrement())
                person   Person      @map(["partner_id", "partner_age"]) @relation("PersonToPerson_partner_id_partner_age")
                persons  Person[]    @relation("PersonToPerson_partner_id_partner_age")
-               
+
                @@unique([id, age], name: "sqlite_autoindex_Person_1")
             }
         "#;
@@ -259,7 +259,7 @@ async fn compound_foreign_keys_should_work_with_defaults(api: &TestApi) {
 // model.indexes contains a multi-field unique index that matches the colums exactly, then it is unique
 // if there are separate uniques it probably should not become a relation
 // what breaks by having an @@unique that refers to fields that do not have a representation on the model anymore due to the merged relation field?
-//#[test_one_connector(connector = "sqlite")]
+//#[test_each_connector(tags("sqlite"))]
 //#[test]
 //async fn compound_foreign_keys_should_work_for_one_to_one_relations_with_separate_uniques(api: &TestApi) {
 //    let barrel = api.barrel();
@@ -298,7 +298,7 @@ async fn compound_foreign_keys_should_work_with_defaults(api: &TestApi) {
 //}
 
 // the fk indexes are created implicitly on mysql
-#[test_one_connector(connector = "sqlite")]
+#[test_each_connector(tags("sqlite"))]
 #[test]
 async fn compound_foreign_keys_should_work_for_one_to_many_relations_with_non_unique_index(api: &TestApi) {
     let barrel = api.barrel();
@@ -324,10 +324,10 @@ async fn compound_foreign_keys_should_work_for_one_to_many_relations_with_non_un
                age      Int
                id       Int                 @id @default(autoincrement())
                posts    Post[]
-               
+
                @@unique([id, age], name: "sqlite_autoindex_User_1")
             }
-            
+
             model Post {
                 id      Int                 @id @default(autoincrement())
                 user    User                @map(["user_id", "user_age"]) @relation(references:[id, age])

--- a/introspection-engine/connectors/sql-introspection-connector/tests/db_specific_introspection/sqlite/remapping_database_names_sqlite.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/tests/db_specific_introspection/sqlite/remapping_database_names_sqlite.rs
@@ -2,7 +2,7 @@ use crate::*;
 use barrel::types;
 use test_harness::*;
 
-#[test_one_connector(connector = "sqlite")]
+#[test_each_connector(tags("sqlite"))]
 async fn remapping_fields_with_invalid_characters_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -39,7 +39,7 @@ async fn remapping_fields_with_invalid_characters_should_work(api: &TestApi) {
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "sqlite")]
+#[test_each_connector(tags("sqlite"))]
 async fn remapping_tables_with_invalid_characters_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -70,7 +70,7 @@ async fn remapping_tables_with_invalid_characters_should_work(api: &TestApi) {
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "sqlite")]
+#[test_each_connector(tags("sqlite"))]
 async fn remapping_models_in_relations_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -93,10 +93,10 @@ async fn remapping_models_in_relations_should_work(api: &TestApi) {
                id       Int                             @id  @default(autoincrement())
                name     String
                post     Post?
-               
+
                @@map("User with Space")
             }
-            
+
             model Post {
                 id                  Int                 @id  @default(autoincrement())
                 user_id     User_with_Space
@@ -106,7 +106,7 @@ async fn remapping_models_in_relations_should_work(api: &TestApi) {
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "sqlite")]
+#[test_each_connector(tags("sqlite"))]
 #[test]
 async fn remapping_models_in_compound_relations_should_work(api: &TestApi) {
     let barrel = api.barrel();
@@ -132,21 +132,21 @@ async fn remapping_models_in_compound_relations_should_work(api: &TestApi) {
                age      Int
                id       Int                             @id  @default(autoincrement())
                post     Post?
-               
+
                @@map("User with Space")
                @@unique([id, age], name: "sqlite_autoindex_User with Space_1")
             }
-           
+
             model Post {
                 id      Int                             @id @default(autoincrement())
-                user_with_Space    User_with_Space      @map(["user_id", "user_age"]) @relation(references:[id, age]) 
+                user_with_Space    User_with_Space      @map(["user_id", "user_age"]) @relation(references:[id, age])
             }
         "#;
     let result = dbg!(api.introspect().await);
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "sqlite")]
+#[test_each_connector(tags("sqlite"))]
 #[test]
 async fn remapping_fields_in_compound_relations_should_work(api: &TestApi) {
     let barrel = api.barrel();
@@ -172,13 +172,13 @@ async fn remapping_fields_in_compound_relations_should_work(api: &TestApi) {
                age_that_is_invalid      Int     @map("age-that-is-invalid")
                id                       Int     @id @default(autoincrement())
                post                     Post?
-               
+
                @@unique([id, age_that_is_invalid], name: "sqlite_autoindex_User_1")
             }
-            
+
             model Post {
                 id                      Int     @id @default(autoincrement())
-                user                    User    @map(["user_id", "user_age"]) @relation(references:[id, age_that_is_invalid]) 
+                user                    User    @map(["user_id", "user_age"]) @relation(references:[id, age_that_is_invalid])
             }
         "#;
     let result = dbg!(api.introspect().await);

--- a/introspection-engine/connectors/sql-introspection-connector/tests/db_specific_introspection/sqlite/tables_sqlite.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/tests/db_specific_introspection/sqlite/tables_sqlite.rs
@@ -2,7 +2,7 @@ use crate::*;
 use barrel::types;
 use test_harness::*;
 
-#[test_one_connector(connector = "sqlite")]
+#[test_each_connector(tags("sqlite"))]
 #[test]
 async fn introspecting_a_simple_table_with_gql_types_must_work(api: &TestApi) {
     let barrel = api.barrel();
@@ -24,7 +24,7 @@ async fn introspecting_a_simple_table_with_gql_types_must_work(api: &TestApi) {
                 date    DateTime
                 float   Float
                 id      Int @id @default(autoincrement())
-                int     Int 
+                int     Int
                 string  String
             }
         "#;
@@ -32,7 +32,7 @@ async fn introspecting_a_simple_table_with_gql_types_must_work(api: &TestApi) {
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "sqlite")]
+#[test_each_connector(tags("sqlite"))]
 async fn introspecting_a_table_with_compound_primary_keys_must_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -56,7 +56,7 @@ async fn introspecting_a_table_with_compound_primary_keys_must_work(api: &TestAp
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "sqlite")]
+#[test_each_connector(tags("sqlite"))]
 async fn introspecting_a_table_with_unique_index_must_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -79,7 +79,7 @@ async fn introspecting_a_table_with_unique_index_must_work(api: &TestApi) {
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "sqlite")]
+#[test_each_connector(tags("sqlite"))]
 async fn introspecting_a_table_with_multi_column_unique_index_must_work(api: &TestApi) {
     let barrel = api.barrel();
     barrel
@@ -105,7 +105,7 @@ async fn introspecting_a_table_with_multi_column_unique_index_must_work(api: &Te
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "sqlite")]
+#[test_each_connector(tags("sqlite"))]
 async fn introspecting_a_table_with_required_and_optional_columns_must_work(api: &TestApi) {
     let barrel = api.barrel();
     barrel
@@ -129,7 +129,7 @@ async fn introspecting_a_table_with_required_and_optional_columns_must_work(api:
     custom_assert(&result, dm);
 }
 
-//#[test_one_connector(connector = "sqlite")]
+//#[test_each_connector(tags("sqlite"))]
 //#[ignore]
 //fn introspecting_a_table_with_datetime_default_values_should_work(api: &TestApi) {
 //    let barrel = api.barrel();
@@ -152,7 +152,7 @@ async fn introspecting_a_table_with_required_and_optional_columns_must_work(api:
 //    custom_assert(&result, dm);
 //}
 
-#[test_one_connector(connector = "sqlite")]
+#[test_each_connector(tags("sqlite"))]
 async fn introspecting_a_table_with_default_values_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -184,7 +184,7 @@ async fn introspecting_a_table_with_default_values_should_work(api: &TestApi) {
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "sqlite")]
+#[test_each_connector(tags("sqlite"))]
 async fn introspecting_a_table_with_a_non_unique_index_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel
@@ -208,7 +208,7 @@ async fn introspecting_a_table_with_a_non_unique_index_should_work(api: &TestApi
     custom_assert(&result, dm);
 }
 
-#[test_one_connector(connector = "sqlite")]
+#[test_each_connector(tags("sqlite"))]
 async fn introspecting_a_table_with_a_multi_column_non_unique_index_should_work(api: &TestApi) {
     let barrel = api.barrel();
     let _setup_schema = barrel

--- a/introspection-engine/connectors/sql-introspection-connector/tests/rpc_calls/get_database_description.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/tests/rpc_calls/get_database_description.rs
@@ -1,7 +1,7 @@
-use crate::{test_harness::*, test_one_connector, BarrelMigrationExecutor};
+use crate::{test_harness::*, BarrelMigrationExecutor};
 use barrel::types;
 
-#[test_one_connector(connector = "mysql")]
+#[test_each_connector(tags("mysql"))]
 async fn database_description_for_mysql_should_work(api: &TestApi) {
     let barrel = api.barrel();
     setup(&barrel, api.db_name()).await;
@@ -9,15 +9,7 @@ async fn database_description_for_mysql_should_work(api: &TestApi) {
     assert_eq!(result, "{\"tables\":[{\"name\":\"Blog\",\"columns\":[{\"name\":\"id\",\"tpe\":{\"raw\":\"int\",\"family\":\"int\",\"arity\":\"required\"},\"default\":null,\"autoIncrement\":true},{\"name\":\"string\",\"tpe\":{\"raw\":\"text\",\"family\":\"string\",\"arity\":\"required\"},\"default\":null,\"autoIncrement\":false}],\"indices\":[],\"primaryKey\":{\"columns\":[\"id\"],\"sequence\":null},\"foreignKeys\":[]}],\"enums\":[],\"sequences\":[]}".to_string());
 }
 
-#[test_one_connector(connector = "mysql_8")]
-async fn database_description_for_mysql_8_should_work(api: &TestApi) {
-    let barrel = api.barrel();
-    setup(&barrel, api.db_name()).await;
-    let result = dbg!(api.get_database_description().await);
-    assert_eq!(result, "{\"tables\":[{\"name\":\"Blog\",\"columns\":[{\"name\":\"id\",\"tpe\":{\"raw\":\"int\",\"family\":\"int\",\"arity\":\"required\"},\"default\":null,\"autoIncrement\":true},{\"name\":\"string\",\"tpe\":{\"raw\":\"text\",\"family\":\"string\",\"arity\":\"required\"},\"default\":null,\"autoIncrement\":false}],\"indices\":[],\"primaryKey\":{\"columns\":[\"id\"],\"sequence\":null},\"foreignKeys\":[]}],\"enums\":[],\"sequences\":[]}".to_string());
-}
-
-#[test_one_connector(connector = "postgres")]
+#[test_each_connector(tags("postgres"))]
 async fn database_description_for_postgres_should_work(api: &TestApi) {
     let barrel = api.barrel();
     setup(&barrel, api.schema_name()).await;
@@ -25,7 +17,7 @@ async fn database_description_for_postgres_should_work(api: &TestApi) {
     assert_eq!(result, "{\"tables\":[{\"name\":\"Blog\",\"columns\":[{\"name\":\"id\",\"tpe\":{\"raw\":\"int4\",\"family\":\"int\",\"arity\":\"required\"},\"default\":\"nextval(\\\"Blog_id_seq\\\"::regclass)\",\"autoIncrement\":true},{\"name\":\"string\",\"tpe\":{\"raw\":\"text\",\"family\":\"string\",\"arity\":\"required\"},\"default\":null,\"autoIncrement\":false}],\"indices\":[],\"primaryKey\":{\"columns\":[\"id\"],\"sequence\":{\"name\":\"Blog_id_seq\",\"initialValue\":1,\"allocationSize\":1}},\"foreignKeys\":[]}],\"enums\":[],\"sequences\":[{\"name\":\"Blog_id_seq\",\"initialValue\":1,\"allocationSize\":1}]}".to_string());
 }
 
-#[test_one_connector(connector = "sqlite")]
+#[test_each_connector(tags("sqlite"))]
 async fn database_description_for_sqlite_should_work(api: &TestApi) {
     let barrel = api.barrel();
     setup(&barrel, api.schema_name()).await;

--- a/introspection-engine/connectors/sql-introspection-connector/tests/rpc_calls/get_metadata_command_tests.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/tests/rpc_calls/get_metadata_command_tests.rs
@@ -1,8 +1,8 @@
 use crate::test_harness::*;
-use crate::{test_one_connector, BarrelMigrationExecutor, TestApi};
+use crate::{BarrelMigrationExecutor, TestApi};
 use barrel::types;
 
-#[test_one_connector(connector = "mysql")]
+#[test_each_connector(tags("mysql"))]
 async fn metadata_for_mysql_should_work(api: &TestApi) {
     let barrel = api.barrel();
     setup(&barrel, api.db_name()).await;
@@ -11,7 +11,7 @@ async fn metadata_for_mysql_should_work(api: &TestApi) {
     assert_eq!(result.size_in_bytes, 49152);
 }
 
-#[test_one_connector(connector = "postgres")]
+#[test_each_connector(tags("postgres"))]
 async fn metadata_for_postgres_should_work(api: &TestApi) {
     let barrel = api.barrel();
     setup(&barrel, api.schema_name()).await;
@@ -20,7 +20,7 @@ async fn metadata_for_postgres_should_work(api: &TestApi) {
     assert_eq!(result.size_in_bytes, 40960);
 }
 
-#[test_one_connector(connector = "sqlite")]
+#[test_each_connector(tags("sqlite"))]
 async fn metadata_for_sqlite_should_work(api: &TestApi) {
     let barrel = api.barrel();
     setup(&barrel, api.schema_name()).await;

--- a/introspection-engine/connectors/sql-introspection-connector/tests/rpc_calls/list_databases_command_tests.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/tests/rpc_calls/list_databases_command_tests.rs
@@ -1,7 +1,7 @@
-use crate::{test_harness::*, test_one_connector, BarrelMigrationExecutor};
+use crate::{test_harness::*, BarrelMigrationExecutor};
 use barrel::types;
 
-#[test_one_connector(connector = "mysql")]
+#[test_each_connector(tags("mysql"))]
 async fn databases_for_mysql_should_work(api: &TestApi) {
     let barrel = api.barrel();
     setup(&barrel, api.db_name());
@@ -9,15 +9,7 @@ async fn databases_for_mysql_should_work(api: &TestApi) {
     assert!(result.contains(&api.db_name().to_string()));
 }
 
-#[test_one_connector(connector = "mysql_8")]
-async fn databases_for_mysql_8_should_work(api: &TestApi) {
-    let barrel = api.barrel();
-    setup(&barrel, api.db_name());
-    let result = dbg!(api.list_databases().await);
-    assert!(result.contains(&api.db_name().to_string()));
-}
-
-#[test_one_connector(connector = "postgres")]
+#[test_each_connector(tags("postgres"))]
 async fn databases_for_postgres_should_work(api: &TestApi) {
     let barrel = api.barrel();
     setup(&barrel, api.schema_name());
@@ -25,7 +17,7 @@ async fn databases_for_postgres_should_work(api: &TestApi) {
     assert!(result.contains(&api.schema_name().to_string()));
 }
 
-#[test_one_connector(connector = "sqlite")]
+#[test_each_connector(tags("sqlite"))]
 async fn databases_for_sqlite_should_work(api: &TestApi) {
     let barrel = api.barrel();
     setup(&barrel, api.schema_name());

--- a/libs/sql-schema-describer/src/mysql.rs
+++ b/libs/sql-schema-describer/src/mysql.rs
@@ -137,7 +137,9 @@ impl SqlSchemaDescriber {
             SELECT column_name column_name, data_type data_type, column_type full_data_type, column_default column_default, is_nullable is_nullable, extra extra
             FROM information_schema.columns
             WHERE table_schema = ? AND table_name = ?
-            ORDER BY column_name";
+            ORDER BY column_name
+            COLLATE utf8_general_ci
+        ";
 
         let rows = self
             .conn

--- a/libs/sql-schema-describer/src/postgres.rs
+++ b/libs/sql-schema-describer/src/postgres.rs
@@ -126,10 +126,13 @@ impl SqlSchemaDescriber {
     }
 
     async fn get_columns(&self, schema: &str, table: &str, enums: &Vec<Enum>) -> Vec<Column> {
-        let sql = "SELECT column_name, data_type, udt_name as full_data_type, column_default, is_nullable, is_identity, data_type
-            FROM information_schema.columns
-            WHERE table_schema = $1 AND table_name = $2
-            ORDER BY column_name";
+        let sql = r#"
+            SELECT column_name, data_type, udt_name as full_data_type, column_default, is_nullable, is_identity, data_type
+                FROM information_schema.columns
+                WHERE table_schema = $1 AND table_name = $2
+                ORDER BY column_name
+            COLLATE "default"
+        "#;
         let rows = self
             .conn
             .query_raw(&sql, &[schema.into(), table.into()])

--- a/migration-engine/migration-engine-tests/tests/error_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/error_tests.rs
@@ -256,7 +256,7 @@ async fn bad_datasource_url_and_provider_combinations_must_return_a_proper_error
     assert_eq!(json_error, expected);
 }
 
-#[test_one_connector(connector = "postgres")]
+#[test_each_connector(tags("postgres"))]
 async fn command_errors_must_return_an_unknown_error(api: &TestApi) {
     let steps = vec![MigrationStep::DeleteModel(DeleteModel {
         model: "abcd".to_owned(),

--- a/migration-engine/migration-engine-tests/tests/existing_data_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data_tests.rs
@@ -4,7 +4,6 @@ use migration_connector::MigrationWarning;
 use migration_engine_tests::sql::*;
 use pretty_assertions::assert_eq;
 use quaint::ast::*;
-use std::borrow::Cow;
 
 #[test_each_connector]
 async fn adding_a_required_field_if_there_is_data(api: &TestApi) {

--- a/migration-engine/migration-engine-tests/tests/existing_databases_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_databases_tests.rs
@@ -160,7 +160,7 @@ async fn creating_a_field_for_an_existing_column_and_simultaneously_making_it_op
     Ok(())
 }
 
-#[test_one_connector(connector = "postgres")]
+#[test_each_connector(tags("postgres"))]
 async fn creating_a_scalar_list_field_for_an_existing_table_must_work(api: &TestApi) -> TestResult {
     let dm1 = r#"
             datasource pg {
@@ -236,7 +236,7 @@ async fn delete_a_field_for_a_non_existent_column_must_work(api: &TestApi) -> Te
     Ok(())
 }
 
-#[test_one_connector(connector = "postgres")]
+#[test_each_connector(tags("postgres"))]
 async fn deleting_a_scalar_list_field_for_a_non_existent_column_must_work(api: &TestApi) -> TestResult {
     let dm1 = r#"
             datasource pg {


### PR DESCRIPTION
test_one_connector goes for the connector with an exactly matching name.
test_each_connector will test all versions of the same family.

This makes the introspection engine tests cover MariaDB too.