### PR TITLE
Multithreaded batch

### DIFF
--- a/migration-engine/migration-engine-tests/tests/existing_data_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data_tests.rs
@@ -4,7 +4,6 @@ use migration_connector::MigrationWarning;
 use migration_engine_tests::sql::*;
 use pretty_assertions::assert_eq;
 use quaint::ast::*;
-use std::borrow::Cow;
 
 #[test_each_connector]
 async fn adding_a_required_field_if_there_is_data(api: &TestApi) {

--- a/query-engine/connector-test-kit/src/test/scala/queries/batch/SelectOneBatchSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/batch/SelectOneBatchSpec.scala
@@ -1,0 +1,83 @@
+package queries.batch
+
+import org.scalatest.{FlatSpec, Matchers}
+import util.{ApiSpecBase, ProjectDsl}
+
+class SelectOneBatchSpec extends FlatSpec with Matchers with ApiSpecBase {
+  val project = ProjectDsl.fromString {
+    """model Artist {
+      |  id       String @id @default(cuid())
+      |  ArtistId Int    @unique
+      |  Name     String
+      |  Albums   Album[]
+      |}
+      |
+      |model Album {
+      |  id      String  @id @default(cuid())
+      |  AlbumId Int     @unique
+      |  Title   String
+      |  Artist  Artist  @relation(references: [id])
+      |  @@index([Artist])
+      |}
+      |"""
+  }
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    database.setup(project)
+
+    server.query(
+      """mutation artistWithoutAlbums {createArtist(data:{
+        |                         Name: "ArtistWithoutAlbums"
+        |                         ArtistId: 1
+        |}){Name}}""",
+      project = project
+    )
+
+    server.query(
+      """mutation artistWithAlbumButWithoutTracks {createArtist(data:{
+        |                         Name: "ArtistWithOneAlbumWithoutTracks"
+        |                         ArtistId: 2,
+        |                         Albums: {create: [
+        |                                   {Title: "TheAlbumWithoutTracks",
+        |                                    AlbumId: 2
+        |                          }]}
+        |}){Name}}""",
+      project = project
+    )
+  }
+
+  "one successful query" should "work" in {
+    server.batch(Array("""query {artist(where:{ArtistId: 1}){Name}}"""), project).toString should be(
+      """[{"data":{"artist":{"Name":"ArtistWithoutAlbums"}}}]"""
+    )
+  }
+
+  "two successful queries" should "work" in {
+    val queries = Array(
+      """query {artist(where:{ArtistId: 1}){Name}}""",
+      """query {artist(where:{ArtistId: 2}){Name}}""",
+    )
+
+    server.batch(queries, project).toString should be(
+      """[{"data":{"artist":{"Name":"ArtistWithoutAlbums"}}},{"data":{"artist":{"Name":"ArtistWithOneAlbumWithoutTracks"}}}]"""
+    )
+  }
+
+  "one singular failing query" should "work" in {
+    server.batch(Array("""query {artist(where:{ArtistId: 420}){Name}}"""), project).toString should be(
+      """[{"data":{"artist":null}}]"""
+    )
+  }
+
+  "one singular failing query out of two" should "work" in {
+    val queries = Array(
+      """query {artist(where:{ArtistId: 1}){Name}}""",
+      """query {artist(where:{ArtistId: 420}){Name}}""",
+    )
+
+    server.batch(queries, project).toString should be(
+      """[{"data":{"artist":{"Name":"ArtistWithoutAlbums"}}},{"data":{"artist":null}}]"""
+    )
+  }
+}

--- a/query-engine/prisma/src/cli.rs
+++ b/query-engine/prisma/src/cli.rs
@@ -1,18 +1,17 @@
 use std::{convert::TryFrom, fs::File, io::Read, sync::Arc};
 
-use graphql_parser as gql;
 use serde::Deserialize;
 
 use datamodel::json::dmmf::Datamodel;
 use query_core::{
-    response_ir,
     schema::{QuerySchemaRef, SupportedCapabilities},
-    BuildMode, CoreError, QuerySchemaBuilder, Responses,
+    BuildMode, QuerySchemaBuilder,
 };
+use std::collections::HashMap;
 
 use crate::context::PrismaContext;
 use crate::error::PrismaError;
-use crate::request_handlers::graphql::*;
+use crate::request_handlers::{graphql::*, PrismaRequest, RequestHandler};
 use crate::{
     data_model_loader::{load_configuration, load_data_model_components},
     dmmf, PrismaResult,
@@ -87,12 +86,12 @@ impl TryFrom<&PrismaOpt> for CliCommand {
 }
 
 impl CliCommand {
-    pub fn execute(self) -> PrismaResult<()> {
+    pub async fn execute(self) -> PrismaResult<()> {
         match self {
             CliCommand::Dmmf(request) => Self::dmmf(request),
             CliCommand::DmmfToDml(input) => Self::dmmf_to_dml(input),
             CliCommand::GetConfig(input) => Self::get_config(input),
-            CliCommand::ExecuteRequest(request) => Self::execute_request(request),
+            CliCommand::ExecuteRequest(request) => Self::execute_request(request).await,
         }
     }
 
@@ -140,65 +139,29 @@ impl CliCommand {
         Ok(())
     }
 
-    fn execute_request(request: ExecuteRequest) -> PrismaResult<()> {
-        use futures::executor::block_on;
-        use futures::FutureExt;
-        use std::panic::AssertUnwindSafe;
-        use user_facing_errors::Error;
-
+    async fn execute_request(request: ExecuteRequest) -> PrismaResult<()> {
         let decoded = base64::decode(&request.query)?;
         let decoded_request = String::from_utf8(decoded)?;
 
-        let cmd =
-            CliCommand::handle_gql_request(decoded_request, request.force_transactions, request.enable_raw_queries);
+        let ctx = PrismaContext::builder()
+            .legacy(true)
+            .force_transactions(request.force_transactions)
+            .enable_raw_queries(request.enable_raw_queries)
+            .build()
+            .await?;
 
-        let response = match block_on(AssertUnwindSafe(cmd).catch_unwind()) {
-            Ok(Ok(responses)) => responses,
-            Ok(Err(err)) => {
-                let mut responses = response_ir::Responses::default();
-                responses.insert_error(err);
-                responses
-            }
-            // panicked
-            Err(err) => {
-                let mut responses = response_ir::Responses::default();
-                let error = Error::from_panic_payload(&err);
-
-                responses.insert_error(error);
-                responses
-            }
+        let req = PrismaRequest {
+            body: serde_json::from_str(&decoded_request).unwrap(),
+            headers: HashMap::new(),
+            path: String::new(),
         };
 
+        let response = GraphQlRequestHandler.handle(req, &Arc::new(ctx)).await;
         let response = serde_json::to_string(&response).unwrap();
 
         let encoded_response = base64::encode(&response);
         print!("{}", encoded_response);
 
         Ok(())
-    }
-
-    async fn handle_gql_request(
-        input: String,
-        force_transactions: bool,
-        enable_raw_queries: bool,
-    ) -> Result<Responses, PrismaError> {
-        let ctx = PrismaContext::builder()
-            .legacy(true)
-            .force_transactions(force_transactions)
-            .enable_raw_queries(enable_raw_queries)
-            .build()
-            .await?;
-
-        let gql_doc = gql::parse_query(&input)?;
-        let query_doc = GraphQLProtocolAdapter::convert(gql_doc, None)?;
-
-        ctx.executor
-            .execute(query_doc, Arc::clone(ctx.query_schema()))
-            .await
-            .map_err(|err| {
-                debug!("{}", err);
-                let ce: CoreError = err.into();
-                ce.into()
-            })
     }
 }

--- a/query-engine/prisma/src/main.rs
+++ b/query-engine/prisma/src/main.rs
@@ -13,7 +13,7 @@ use tracing_subscriber::{EnvFilter, FmtSubscriber};
 use cli::*;
 use error::*;
 use lazy_static::lazy_static;
-use request_handlers::{PrismaRequest, RequestHandler};
+use request_handlers::{PrismaRequest, PrismaResponse, RequestHandler};
 use server::HttpServer;
 
 mod cli;
@@ -112,7 +112,7 @@ async fn main() -> Result<(), AnyError> {
 
     match CliCommand::try_from(&opts) {
         Ok(cmd) => {
-            if let Err(err) = cmd.execute() {
+            if let Err(err) = cmd.execute().await {
                 info!("Encountered error during initialization:");
                 err.render_as_json().expect("error rendering");
                 process::exit(1);

--- a/query-engine/prisma/src/request_handlers/graphql/protocol_adapter.rs
+++ b/query-engine/prisma/src/request_handlers/graphql/protocol_adapter.rs
@@ -31,7 +31,7 @@ impl GraphQLProtocolAdapter {
                 .ok_or_else(|| {
                     PrismaError::QueryConversionError(format!("Operation '{}' does not match any query.", op))
                 })
-                .and_then(|def| Self::convert_definition(def)),
+                .and_then(Self::convert_definition),
 
             None => gql_doc
                 .definitions

--- a/query-engine/prisma/src/request_handlers/mod.rs
+++ b/query-engine/prisma/src/request_handlers/mod.rs
@@ -5,13 +5,20 @@ pub use query_core::{response_ir, schema::QuerySchemaRenderer};
 
 use crate::context::PrismaContext;
 use async_trait::async_trait;
-use std::{collections::HashMap, fmt::Debug};
+use std::{collections::HashMap, fmt::Debug, sync::Arc};
+
+#[derive(Debug, serde::Serialize)]
+#[serde(untagged)]
+pub enum PrismaResponse {
+    Single(response_ir::Responses),
+    Multi(Vec<PrismaResponse>),
+}
 
 #[async_trait]
 pub trait RequestHandler {
     type Body: Debug;
 
-    async fn handle<S>(&self, req: S, ctx: &PrismaContext) -> response_ir::Responses
+    async fn handle<S>(&self, req: S, ctx: &Arc<PrismaContext>) -> PrismaResponse
     where
         S: Into<PrismaRequest<Self::Body>> + Send + Sync + 'static;
 }


### PR DESCRIPTION
This implements the batching protocol, where every single query runs in parallel in separate threads.

The request should hold the queries in an array:
```json
{
    "batch": [
        {
            "query": "query {findOneArtist(where: { id: 1 }) {Name}}",
            "variables": {}
        },
        {
            "query": "query {findOneArtist(where: { id: 2 }) {Name}}",
            "variables": {}
        }
    ]
}
```
Responses will come back in the same order in an array:
```json
[
  {
    "data": {
      "artist": {
        "Name": "ArtistWithoutAlbums"
      }
    }
  },
  {
    "data": {
      "artist": {
        "Name": "ArtistWithOneAlbumWithoutTracks"
      }
    }
  }
]
```