### PR TITLE
Avoid recompilation of regular expressions in introspection engine

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/Cargo.toml
+++ b/introspection-engine/connectors/sql-introspection-connector/Cargo.toml
@@ -21,6 +21,7 @@ user-facing-errors = { path = "../../../libs/user-facing-errors", features = ["s
 tracing = "0.1.10"
 tracing-futures = "0.2.0"
 tokio = { version = "0.2", features = ["rt-threaded", "time"] }
+once_cell = "1.3.1"
 
 [dependencies.quaint]
 git = "https://github.com/prisma/quaint"

--- a/introspection-engine/connectors/sql-introspection-connector/src/misc_helpers.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/misc_helpers.rs
@@ -4,6 +4,7 @@ use datamodel::{
     ScalarValue, ValueGenerator,
 };
 use log::debug;
+use once_cell::sync::Lazy;
 use regex::Regex;
 use sql_schema_describer::{Column, ColumnArity, ColumnTypeFamily, ForeignKey, Index, IndexType, SqlSchema, Table};
 
@@ -370,10 +371,11 @@ pub fn deduplicate_names_of_fields_to_be_added(fields_to_be_added: &mut Vec<(Str
     });
 }
 
+static RE_NUM: Lazy<Regex> = Lazy::new(|| Regex::new(r"^'?(\d+)'?$").expect("compile regex"));
+
 fn parse_int(value: &str) -> Option<i32> {
     debug!("Parsing int '{}'", value);
-    let re_num = Regex::new(r"^'?(\d+)'?$").expect("compile regex");
-    let rslt = re_num.captures(value);
+    let rslt = RE_NUM.captures(value);
     if rslt.is_none() {
         debug!("Couldn't parse int");
         return None;
@@ -396,10 +398,11 @@ fn parse_bool(value: &str) -> Option<bool> {
     value.to_lowercase().parse().ok()
 }
 
+static RE_FLOAT: Lazy<Regex> = Lazy::new(|| Regex::new(r"^'?([^']+)'?$").expect("compile regex"));
+
 fn parse_float(value: &str) -> Option<f32> {
     debug!("Parsing float '{}'", value);
-    let re_num = Regex::new(r"^'?([^']+)'?$").expect("compile regex");
-    let rslt = re_num.captures(value);
+    let rslt = RE_FLOAT.captures(value);
     if rslt.is_none() {
         debug!("Couldn't parse float");
         return None;

--- a/introspection-engine/connectors/sql-introspection-connector/src/sanitize_datamodel_names.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/sanitize_datamodel_names.rs
@@ -1,4 +1,5 @@
 use datamodel::{Datamodel, FieldType};
+use once_cell::sync::Lazy;
 use regex::Regex;
 use std::collections::HashMap;
 
@@ -72,14 +73,16 @@ pub fn sanitize_datamodel_names(datamodel: &mut Datamodel) {
     }
 }
 
+static RE_START: Lazy<Regex> = Lazy::new(|| Regex::new("^[^a-zA-Z]+").unwrap());
+
+static RE: Lazy<Regex> = Lazy::new(|| Regex::new("[^_a-zA-Z0-9]").unwrap());
+
 fn sanitize_name(name: String) -> (String, Option<String>) {
-    let re_start = Regex::new("^[^a-zA-Z]+").unwrap();
-    let re = Regex::new("[^_a-zA-Z0-9]").unwrap();
-    let needs_sanitation = re_start.is_match(name.as_str()) || re.is_match(name.as_str());
+    let needs_sanitation = RE_START.is_match(name.as_str()) || RE.is_match(name.as_str());
 
     if needs_sanitation {
-        let start_cleaned: String = re_start.replace_all(name.as_str(), "").parse().unwrap();
-        (re.replace_all(start_cleaned.as_str(), "_").parse().unwrap(), Some(name))
+        let start_cleaned: String = RE_START.replace_all(name.as_str(), "").parse().unwrap();
+        (RE.replace_all(start_cleaned.as_str(), "_").parse().unwrap(), Some(name))
     } else {
         (name, None)
     }


### PR DESCRIPTION
The calls were frequent enough that it was showing quite a lot in the flamegraphs.